### PR TITLE
contract: fix malicious relayer start

### DIFF
--- a/packages/contract/src/DaimoPay.sol
+++ b/packages/contract/src/DaimoPay.sol
@@ -83,8 +83,8 @@ contract DaimoPay is ReentrancyGuard {
     event IntentRefunded(
         address indexed intentAddr,
         address indexed refundAddr,
-        address token,
-        uint256 amount,
+        IERC20[] tokens,
+        uint256[] amounts,
         PayIntent intent
     );
 
@@ -95,6 +95,7 @@ contract DaimoPay is ReentrancyGuard {
     /// Starts an intent, bridging to the destination chain if necessary.
     function startIntent(
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata calls,
         bytes calldata bridgeExtraData
     ) public nonReentrant {
@@ -105,14 +106,62 @@ contract DaimoPay is ReentrancyGuard {
         require(!intentSent[address(intentContract)], "DP: already sent");
         intentSent[address(intentContract)] = true;
 
-        // Bridge funds in the intent contract to the destination chain, if
-        // necessary. They'll arrive at the same intent address on chain B.
-        intentContract.start({
-            intent: intent,
-            caller: payable(msg.sender),
-            calls: calls,
-            bridgeExtraData: bridgeExtraData
-        });
+        // Transfer from intent contract to this contract
+        intentContract.sendToEscrow({intent: intent, tokens: paymentTokens});
+
+        // Run arbitrary calls provided by the relayer. These will generally
+        // approve the swap contract and swap if necessary.
+        _executeCalls(calls);
+
+        if (intent.toChainId == block.chainid) {
+            // Same chain. Check that the relayer calls produced enough output
+            // tokens.
+            bool balanceOk = _checkBridgeTokenOutBalance(
+                intent.bridgeTokenOutOptions
+            );
+            require(balanceOk, "PI: insufficient token");
+
+            // Send tokens to the intent address for later claimIntent.
+            uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
+            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
+                TokenUtils.transferBalance({
+                    token: intent.bridgeTokenOutOptions[i].token,
+                    recipient: payable(address(intentContract))
+                });
+            }
+        } else {
+            // Different chains. Get the input token and amount required to
+            // initiate bridging
+            IDaimoPayBridger bridger = intent.bridger;
+            (address bridgeTokenIn, uint256 inAmount) = bridger
+                .getBridgeTokenIn({
+                    toChainId: intent.toChainId,
+                    bridgeTokenOutOptions: intent.bridgeTokenOutOptions
+                });
+
+            // Check that the swap produced sufficient tokens to initiate
+            // bridging.
+            uint256 balance = IERC20(bridgeTokenIn).balanceOf(address(this));
+            require(balance >= inAmount, "PI: insufficient bridge token");
+
+            // Approve bridger and initiate bridging
+            IERC20(bridgeTokenIn).forceApprove({
+                spender: address(bridger),
+                value: inAmount
+            });
+            bridger.sendToChain({
+                toChainId: intent.toChainId,
+                toAddress: address(intentContract),
+                bridgeTokenOutOptions: intent.bridgeTokenOutOptions,
+                extraData: bridgeExtraData
+            });
+
+            // Refund any leftover tokens in the contract to the caller
+            TokenUtils.transferBalance({
+                token: IERC20(bridgeTokenIn),
+                recipient: payable(msg.sender)
+            });
+        }
 
         emit Start({intentAddr: address(intentContract), intent: intent});
     }
@@ -166,14 +215,25 @@ contract DaimoPay is ReentrancyGuard {
 
         PayIntentContract intentContract = intentFactory.createIntent(intent);
 
-        // Transfer from intent contract to this contract
-        intentContract.claim(intent);
-
-        // Finally, forward the balance to the current recipient
+        // Check the recipient for this intent.
         address recipient = intentToRecipient[address(intentContract)];
         // If intent is double-paid after it has already been claimed, then
         // the recipient should call refundIntent to get their funds back.
         require(recipient != ADDR_MAX, "DP: already claimed");
+
+        // Transfer from intent contract to this contract
+        uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
+        IERC20[] memory tokens = new IERC20[](tokenOptionsLength);
+        for (uint256 i = 0; i < tokenOptionsLength; ++i) {
+            tokens[i] = intent.bridgeTokenOutOptions[i].token;
+        }
+        intentContract.sendToEscrow({intent: intent, tokens: tokens});
+
+        // Check that enough tokens were received. Revert otherwise.
+        bool balanceOk = _checkBridgeTokenOutBalance(
+            intent.bridgeTokenOutOptions
+        );
+        require(balanceOk, "DP: insufficient token received");
 
         if (recipient == address(0)) {
             // No relayer showed up, so just complete the intent.
@@ -186,14 +246,10 @@ contract DaimoPay is ReentrancyGuard {
                 calls: calls
             });
         } else {
-            // Otherwise, the relayer fastFinished the intent. Repay them. The
-            // intent contract checks that the received amount is sufficient, so
-            // we can simply transfer the balance.
-            uint256 n = intent.bridgeTokenOutOptions.length;
-            for (uint256 i = 0; i < n; ++i) {
-                TokenAmount calldata tokenOut = intent.bridgeTokenOutOptions[i];
+            // Otherwise, the relayer fastFinished the intent. Repay them.
+            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
                 TokenUtils.transferBalance({
-                    token: tokenOut.token,
+                    token: tokens[i],
                     recipient: payable(recipient)
                 });
             }
@@ -213,7 +269,7 @@ contract DaimoPay is ReentrancyGuard {
     /// if the intent has already been claimed.
     function refundIntent(
         PayIntent calldata intent,
-        IERC20 token
+        IERC20[] calldata tokens
     ) public nonReentrant {
         PayIntentContract intentContract = intentFactory.createIntent(intent);
         address intentAddr = address(intentContract);
@@ -227,16 +283,26 @@ contract DaimoPay is ReentrancyGuard {
             require(intentSent[intentAddr], "DP: not started");
         }
 
-        // Collect and refund overpaid amount.
-        uint256 amount = intentContract.refund(intent, token);
-        require(amount > 0, "DP: no funds to refund");
-        TokenUtils.transfer(token, payable(intent.refundAddress), amount);
+        // Collect tokens from intent contract.
+        uint256[] memory amounts = intentContract.sendToEscrow({
+            intent: intent,
+            tokens: tokens
+        });
+
+        // Refund tokens to the refund address
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            TokenUtils.transfer({
+                token: tokens[i],
+                recipient: payable(intent.refundAddress),
+                amount: amounts[i]
+            });
+        }
 
         emit IntentRefunded({
             intentAddr: intentAddr,
             refundAddr: intent.refundAddress,
-            token: address(token),
-            amount: amount,
+            tokens: tokens,
+            amounts: amounts,
             intent: intent
         });
     }
@@ -252,11 +318,7 @@ contract DaimoPay is ReentrancyGuard {
     ) internal {
         // Run arbitrary calls provided by the relayer. These will generally
         // approve the swap contract and swap if necessary.
-        for (uint256 i = 0; i < calls.length; ++i) {
-            Call calldata call = calls[i];
-            (bool callSuccess, ) = call.to.call{value: call.value}(call.data);
-            require(callSuccess, "DP: swap call failed");
-        }
+        _executeCalls(calls);
 
         // Check that the swap had a fair price
         uint256 finalCallTokenBalance = TokenUtils.getBalanceOf({
@@ -309,6 +371,34 @@ contract DaimoPay is ReentrancyGuard {
             token: intent.finalCallToken.token,
             recipient: payable(msg.sender)
         });
+    }
+
+    /// Check if the contract has enough balance for at least one of the bridge
+    /// token output options.
+    function _checkBridgeTokenOutBalance(
+        TokenAmount[] calldata bridgeTokenOutOptions
+    ) internal view returns (bool) {
+        uint256 n = bridgeTokenOutOptions.length;
+        bool balanceOk = false;
+        for (uint256 i = 0; i < n; ++i) {
+            TokenAmount calldata tokenOut = bridgeTokenOutOptions[i];
+            uint256 balance = tokenOut.token.balanceOf(address(this));
+            if (balance >= tokenOut.amount) {
+                balanceOk = true;
+                break;
+            }
+        }
+        return balanceOk;
+    }
+
+    /// Execute arbitrary calls. Revert if any fail.
+    function _executeCalls(Call[] calldata calls) internal {
+        uint256 n = calls.length;
+        for (uint256 i = 0; i < n; ++i) {
+            Call calldata call = calls[i];
+            (bool success, ) = call.to.call{value: call.value}(call.data);
+            require(success, "DP: call failed");
+        }
     }
 
     receive() external payable {}

--- a/packages/contract/src/PayIntent.sol
+++ b/packages/contract/src/PayIntent.sol
@@ -58,117 +58,23 @@ contract PayIntentContract is Initializable, ReentrancyGuard {
         intentHash = _intentHash;
     }
 
-    /// Check if the contract has enough balance for at least one of the bridge
-    /// token output options.
-    function checkBridgeTokenOutBalance(
-        TokenAmount[] calldata bridgeTokenOutOptions
-    ) public view returns (bool) {
-        bool balanceOk = false;
-        for (uint256 i = 0; i < bridgeTokenOutOptions.length; ++i) {
-            TokenAmount calldata tokenOut = bridgeTokenOutOptions[i];
-            uint256 balance = tokenOut.token.balanceOf(address(this));
-            if (balance >= tokenOut.amount) {
-                balanceOk = true;
-                break;
-            }
-        }
-        return balanceOk;
-    }
-
-    /// Called on the source chain to start the intent. Run the calls specified
-    /// by the relayer, then send funds to the bridger for cross-chain intents.
-    function start(
+    /// Send funds to the escrow contract for processing.
+    function sendToEscrow(
         PayIntent calldata intent,
-        address payable caller,
-        Call[] calldata calls,
-        bytes calldata bridgeExtraData
-    ) public nonReentrant {
+        IERC20[] calldata tokens
+    ) public nonReentrant returns (uint256[] memory amounts) {
         require(calcIntentHash(intent) == intentHash, "PI: intent");
         require(msg.sender == intent.escrow, "PI: only escrow");
 
-        // Run arbitrary calls provided by the relayer. These will generally
-        // approve the swap contract and swap if necessary.
-        for (uint256 i = 0; i < calls.length; ++i) {
-            Call calldata call = calls[i];
-            (bool success, ) = call.to.call{value: call.value}(call.data);
-            require(success, "PI: swap call failed");
-        }
-
-        if (intent.toChainId == block.chainid) {
-            // Same chain. Check that the contract has sufficient token balance.
-            bool balanceOk = checkBridgeTokenOutBalance(
-                intent.bridgeTokenOutOptions
-            );
-            require(balanceOk, "PI: insufficient token");
-        } else {
-            // Different chains. Get the input token and amount required to
-            // initiate bridging
-            IDaimoPayBridger bridger = intent.bridger;
-            (address bridgeTokenIn, uint256 inAmount) = bridger
-                .getBridgeTokenIn({
-                    toChainId: intent.toChainId,
-                    bridgeTokenOutOptions: intent.bridgeTokenOutOptions
-                });
-
-            uint256 balance = IERC20(bridgeTokenIn).balanceOf(address(this));
-            require(balance >= inAmount, "PI: insufficient bridge token");
-
-            // Approve bridger and initiate bridging
-            IERC20(bridgeTokenIn).forceApprove({
-                spender: address(bridger),
-                value: inAmount
-            });
-            bridger.sendToChain({
-                toChainId: intent.toChainId,
-                toAddress: address(this),
-                bridgeTokenOutOptions: intent.bridgeTokenOutOptions,
-                extraData: bridgeExtraData
-            });
-
-            // Refund any leftover tokens in the contract to the caller
-            TokenUtils.transferBalance({
-                token: IERC20(bridgeTokenIn),
-                recipient: caller
-            });
-        }
-    }
-
-    /// Check that there is sufficient output token and send tokens to the
-    /// escrow contract.
-    function claim(PayIntent calldata intent) public nonReentrant {
-        require(keccak256(abi.encode(intent)) == intentHash, "PI: intent");
-        require(msg.sender == intent.escrow, "PI: only escrow");
-        require(block.chainid == intent.toChainId, "PI: only dest chain");
-
-        bool balanceOk = checkBridgeTokenOutBalance(
-            intent.bridgeTokenOutOptions
-        );
-        require(balanceOk, "PI: insufficient token received");
-
-        // Send to escrow contract, which will forward to current recipient
-        uint256 n = intent.bridgeTokenOutOptions.length;
+        uint256 n = tokens.length;
+        amounts = new uint256[](n);
+        // Send tokens to escrow contract
         for (uint256 i = 0; i < n; ++i) {
-            TokenUtils.transferBalance({
-                token: intent.bridgeTokenOutOptions[i].token,
+            amounts[i] = TokenUtils.transferBalance({
+                token: tokens[i],
                 recipient: intent.escrow
             });
         }
-    }
-
-    /// Refund double payments.
-    function refund(
-        PayIntent calldata intent,
-        IERC20 token
-    ) public nonReentrant returns (uint256 amount) {
-        require(calcIntentHash(intent) == intentHash, "PI: intent");
-        require(msg.sender == intent.escrow, "PI: only escrow");
-
-        // Send to escrow contract, which will forward to the refund address.
-        amount = TokenUtils.transferBalance({
-            token: token,
-            recipient: intent.escrow
-        });
-        require(amount > 0, "PI: no funds to refund");
     }
 
     /// Accept native-token (eg ETH) inputs

--- a/packages/contract/src/relayer/DaimoPayRelayer.sol
+++ b/packages/contract/src/relayer/DaimoPayRelayer.sol
@@ -190,6 +190,7 @@ contract DaimoPayRelayer is AccessControl {
         Call[] calldata preCalls,
         DaimoPay dp,
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata startCalls,
         bytes calldata bridgeExtraData,
         Call[] calldata postCalls
@@ -203,6 +204,7 @@ contract DaimoPayRelayer is AccessControl {
 
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: startCalls,
             bridgeExtraData: bridgeExtraData
         });

--- a/packages/contract/test/DaimoPay.t.sol
+++ b/packages/contract/test/DaimoPay.t.sol
@@ -373,8 +373,11 @@ contract DaimoPayTest is Test {
         // Since we're already on dest chain, startIntent verifies that we have
         // enough of bridgeTokenOut (see bridgeTokenOutOptions) post swap.
         // Simplest case: no swap, initial payment was already in correct token.
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _toToken;
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -389,10 +392,13 @@ contract DaimoPayTest is Test {
         PayIntent memory intent = getSimpleSameChainPayIntent();
         address intentAddr = intentFactory.getIntentAddress(intent);
 
+        IERC20[] memory refundTokens = new IERC20[](1);
+        refundTokens[0] = _toToken;
+
         // Since we are on the dest chain already, we *cannot* refund after
         // startIntent.
         vm.expectRevert(bytes("DP: not claimed"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Fast-finish it, fronting some native token.
         (bool success, ) = payable(address(dp)).call{value: 100}("");
@@ -401,16 +407,12 @@ contract DaimoPayTest is Test {
 
         // We still can't refund.
         vm.expectRevert(bytes("DP: not claimed"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Claim the intent.
         require(_toToken.balanceOf(intentAddr) == 100);
         dp.claimIntent({intent: intent, calls: new Call[](0)});
         require(_toToken.balanceOf(intentAddr) == 0);
-
-        // Nothing to refund.
-        vm.expectRevert(bytes("PI: no funds to refund"));
-        dp.refundIntent({intent: intent, token: _toToken});
 
         // Double-pay the intent...
         vm.prank(_alice);
@@ -419,7 +421,7 @@ contract DaimoPayTest is Test {
         assertEq(_toToken.balanceOf(_alice), 355);
 
         // ...and refund.
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Check that the intent was refunded.
         assertEq(_toToken.balanceOf(intentAddr), 0);
@@ -473,9 +475,12 @@ contract DaimoPayTest is Test {
         vm.expectEmit(address(dp));
         emit DaimoPay.Start(CCTP_INTENT_ADDR, intent);
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -512,16 +517,15 @@ contract DaimoPayTest is Test {
         PayIntent memory intent = getSimpleCrossChainPayIntent();
         address intentAddr = intentFactory.getIntentAddress(intent);
 
+        IERC20[] memory refundTokens = new IERC20[](1);
+        refundTokens[0] = _fromToken;
+
         // The intent hasn't been started yet, so we can't refund.
         vm.expectRevert(bytes("DP: not started"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Start the intent.
         testSimpleCCTPStart();
-
-        // Nothing to refund.
-        vm.expectRevert(bytes("PI: no funds to refund"));
-        dp.refundIntent({intent: intent, token: _toToken});
 
         // Double-pay the intent...
         vm.chainId(_fromChainId);
@@ -531,7 +535,7 @@ contract DaimoPayTest is Test {
         assertEq(_fromToken.balanceOf(_alice), 355);
 
         // ...and refund.
-        dp.refundIntent({intent: intent, token: _fromToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Check that the intent was refunded.
         assertEq(_fromToken.balanceOf(intentAddr), 0);
@@ -581,9 +585,12 @@ contract DaimoPayTest is Test {
         DaimoPayCCTPV2Bridger.ExtraData memory extraData = DaimoPayCCTPV2Bridger
             .ExtraData({maxFee: 0, minFinalityThreshold: 2000});
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: abi.encode(extraData)
         });
@@ -671,14 +678,17 @@ contract DaimoPayTest is Test {
 
         // Extra tokens should be refunded to the caller
         vm.expectEmit(address(_fromToken));
-        emit IERC20.Transfer(ACROSS_INTENT_ADDR, _alice, 10);
+        emit IERC20.Transfer(address(dp), _alice, 10);
 
         vm.expectEmit(address(dp));
         emit DaimoPay.Start(ACROSS_INTENT_ADDR, intent);
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: abi.encode(extraData)
         });
@@ -759,9 +769,12 @@ contract DaimoPayTest is Test {
             })
         );
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: bridgeExtraData
         });
@@ -991,7 +1004,7 @@ contract DaimoPayTest is Test {
             nonce: _nonce
         });
 
-        vm.expectRevert("PI: insufficient token received");
+        vm.expectRevert("DP: insufficient token received");
 
         dp.claimIntent({intent: intent, calls: new Call[](0)});
 
@@ -1033,9 +1046,12 @@ contract DaimoPayTest is Test {
         _unregisteredToken.transfer(intentAddr, _toAmount);
 
         // Expect revert due to token mismatch
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _unregisteredToken;
         vm.expectRevert();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -1069,9 +1085,12 @@ contract DaimoPayTest is Test {
         _unregisteredToken.transfer(intentAddr, _toAmount);
 
         // Expect revert due to token mismatch
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _unregisteredToken;
         vm.expectRevert();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -1131,5 +1150,98 @@ contract DaimoPayTest is Test {
         );
         // The Linea bridge route uses (_fromToken, _toToken) as the bridge token
         assertEq(actualSmallInputToken, address(_fromToken), "incorrect token");
+    }
+
+    // Assuming that Alice has already transferred to the intent address
+    // Assuming that relayer has already called `startIntent` on the source chain
+    // We are on the destination chain
+    // Before tokens have been successfully transferred to the bridge
+    // Before the relayer has called `fastFinishIntent` on the destination chain
+    function testMaliciousStartIntentOnDest() public {
+        vm.chainId(_acrossDestChainId);
+
+        PayIntent memory intent = PayIntent({
+            toChainId: _acrossDestChainId,
+            bridgeTokenOutOptions: getBridgeTokenOutOptions(),
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount}),
+            finalCall: Call({to: _bob, value: 0, data: ""}),
+            escrow: payable(address(dp)),
+            bridger: bridger,
+            refundAddress: _alice,
+            nonce: _nonce
+        });
+
+        address intentAddress = intentFactory.getIntentAddress(intent);
+
+        // Malicious relayer does these actions
+        address maliciousRelayer = address(
+            0x4444444444444444444444444444444444444444
+        );
+        _toToken.transfer(maliciousRelayer, _toAmount);
+        vm.startPrank(maliciousRelayer);
+
+        // Malicious relayer will call `startIntent` and make an infinite
+        // approval to himself
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call(
+            address(_toToken),
+            0,
+            abi.encodeCall(
+                IERC20.approve,
+                (maliciousRelayer, type(uint256).max)
+            )
+        );
+
+        // Attacker calls `startIntent` on the destination chain, provides funds
+        // so no revert
+        _toToken.transfer(address(intentAddress), _toAmount);
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _toToken;
+        dp.startIntent({
+            intent: intent,
+            paymentTokens: paymentTokens,
+            calls: calls,
+            bridgeExtraData: ""
+        });
+        // Attacker tries using the allowance from the arbitrary call to take
+        // their amount back out of the intent address immediately. This should
+        // revert because the approval is from the escrow contract, not the
+        // intent address.
+        uint256 intentBalance = _toToken.balanceOf(intentAddress);
+        vm.expectRevert();
+        _toToken.transferFrom(
+            intentAddress,
+            address(maliciousRelayer),
+            intentBalance
+        );
+        // Attacker tries taking funds from the escrow contract. The escrow
+        // contract has not tokens, so the relayer gets nothing.
+        uint256 escrowBalance = _toToken.balanceOf(address(dp));
+        assertEq(escrowBalance, 0);
+        _toToken.transferFrom(
+            address(dp),
+            address(maliciousRelayer),
+            escrowBalance
+        );
+        assertEq(_toToken.balanceOf(maliciousRelayer), 0);
+
+        console.log("intentBalance", _toToken.balanceOf(intentAddress));
+        console.log("maliciousBalance", _toToken.balanceOf(maliciousRelayer));
+
+        vm.stopPrank();
+
+        // Now the actual funds arrive from the cross-chain bridge
+        _toToken.transfer(intentAddress, _toAmount);
+
+        // Attacker comes in and tries to take funds before a fastFinishIntent
+        // can be called by genuine relayer
+        vm.startPrank(maliciousRelayer);
+        uint256 intentBalance2 = _toToken.balanceOf(intentAddress);
+        vm.expectRevert();
+        _toToken.transferFrom(intentAddress, maliciousRelayer, intentBalance2);
+        vm.stopPrank();
+
+        console.log("intentBalance", _toToken.balanceOf(intentAddress));
+        console.log("maliciousBalance", _toToken.balanceOf(maliciousRelayer));
     }
 }

--- a/packages/contract/test/Relayer.t.sol
+++ b/packages/contract/test/Relayer.t.sol
@@ -57,6 +57,9 @@ contract RelayerTest is Test {
     }
 
     function testOnlyRelayerRoleCanStartIntent() public {
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _token1;
+
         vm.startPrank(_noRole);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -69,6 +72,7 @@ contract RelayerTest is Test {
             preCalls: new Call[](0),
             dp: DaimoPay(payable(address(mockDp))),
             intent: createSampleIntent(),
+            paymentTokens: paymentTokens,
             startCalls: new Call[](0),
             bridgeExtraData: "",
             postCalls: new Call[](0)
@@ -80,6 +84,7 @@ contract RelayerTest is Test {
             preCalls: new Call[](0),
             dp: DaimoPay(payable(address(mockDp))),
             intent: createSampleIntent(),
+            paymentTokens: paymentTokens,
             startCalls: new Call[](0),
             bridgeExtraData: "",
             postCalls: new Call[](0)
@@ -575,6 +580,7 @@ contract MockDaimoPay {
 
     function startIntent(
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata calls,
         bytes calldata bridgeExtraData
     ) public {}


### PR DESCRIPTION
The fix is to introduce and enforce two invariants:
- the intent contract never makes any calls
- the `DaimoPay` escrow contract never holds any funds

Funds are only ever held in the intent contract between txs. The relayer's arbitrary contract calls are executed by the escrow contract instead of the intent contract to prevent any malicious approvals from the intent contract.