### PR TITLE
NM-0500 Audit fixes

### DIFF
--- a/packages/contract/src/DaimoPay.sol
+++ b/packages/contract/src/DaimoPay.sol
@@ -83,8 +83,8 @@ contract DaimoPay is ReentrancyGuard {
     event IntentRefunded(
         address indexed intentAddr,
         address indexed refundAddr,
-        address token,
-        uint256 amount,
+        IERC20[] tokens,
+        uint256[] amounts,
         PayIntent intent
     );
 
@@ -95,6 +95,7 @@ contract DaimoPay is ReentrancyGuard {
     /// Starts an intent, bridging to the destination chain if necessary.
     function startIntent(
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata calls,
         bytes calldata bridgeExtraData
     ) public nonReentrant {
@@ -105,14 +106,62 @@ contract DaimoPay is ReentrancyGuard {
         require(!intentSent[address(intentContract)], "DP: already sent");
         intentSent[address(intentContract)] = true;
 
-        // Bridge funds in the intent contract to the destination chain, if
-        // necessary. They'll arrive at the same intent address on chain B.
-        intentContract.start({
-            intent: intent,
-            caller: payable(msg.sender),
-            calls: calls,
-            bridgeExtraData: bridgeExtraData
-        });
+        // Transfer from intent contract to this contract
+        intentContract.sendToEscrow({intent: intent, tokens: paymentTokens});
+
+        // Run arbitrary calls provided by the relayer. These will generally
+        // approve the swap contract and swap if necessary.
+        _executeCalls(calls);
+
+        if (intent.toChainId == block.chainid) {
+            // Same chain. Check that the relayer calls produced enough output
+            // tokens.
+            bool balanceOk = _checkBridgeTokenOutBalance(
+                intent.bridgeTokenOutOptions
+            );
+            require(balanceOk, "PI: insufficient token");
+
+            // Send tokens to the intent address for later claimIntent.
+            uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
+            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
+                TokenUtils.transferBalance({
+                    token: intent.bridgeTokenOutOptions[i].token,
+                    recipient: payable(address(intentContract))
+                });
+            }
+        } else {
+            // Different chains. Get the input token and amount required to
+            // initiate bridging
+            IDaimoPayBridger bridger = intent.bridger;
+            (address bridgeTokenIn, uint256 inAmount) = bridger
+                .getBridgeTokenIn({
+                    toChainId: intent.toChainId,
+                    bridgeTokenOutOptions: intent.bridgeTokenOutOptions
+                });
+
+            // Check that the swap produced sufficient tokens to initiate
+            // bridging.
+            uint256 balance = IERC20(bridgeTokenIn).balanceOf(address(this));
+            require(balance >= inAmount, "PI: insufficient bridge token");
+
+            // Approve bridger and initiate bridging
+            IERC20(bridgeTokenIn).forceApprove({
+                spender: address(bridger),
+                value: inAmount
+            });
+            bridger.sendToChain({
+                toChainId: intent.toChainId,
+                toAddress: address(intentContract),
+                bridgeTokenOutOptions: intent.bridgeTokenOutOptions,
+                extraData: bridgeExtraData
+            });
+
+            // Refund any leftover tokens in the contract to the caller
+            TokenUtils.transferBalance({
+                token: IERC20(bridgeTokenIn),
+                recipient: payable(msg.sender)
+            });
+        }
 
         emit Start({intentAddr: address(intentContract), intent: intent});
     }
@@ -166,14 +215,25 @@ contract DaimoPay is ReentrancyGuard {
 
         PayIntentContract intentContract = intentFactory.createIntent(intent);
 
-        // Transfer from intent contract to this contract
-        intentContract.claim(intent);
-
-        // Finally, forward the balance to the current recipient
+        // Check the recipient for this intent.
         address recipient = intentToRecipient[address(intentContract)];
         // If intent is double-paid after it has already been claimed, then
         // the recipient should call refundIntent to get their funds back.
         require(recipient != ADDR_MAX, "DP: already claimed");
+
+        // Transfer from intent contract to this contract
+        uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
+        IERC20[] memory tokens = new IERC20[](tokenOptionsLength);
+        for (uint256 i = 0; i < tokenOptionsLength; ++i) {
+            tokens[i] = intent.bridgeTokenOutOptions[i].token;
+        }
+        intentContract.sendToEscrow({intent: intent, tokens: tokens});
+
+        // Check that enough tokens were received. Revert otherwise.
+        bool balanceOk = _checkBridgeTokenOutBalance(
+            intent.bridgeTokenOutOptions
+        );
+        require(balanceOk, "DP: insufficient token received");
 
         if (recipient == address(0)) {
             // No relayer showed up, so just complete the intent.
@@ -186,14 +246,10 @@ contract DaimoPay is ReentrancyGuard {
                 calls: calls
             });
         } else {
-            // Otherwise, the relayer fastFinished the intent. Repay them. The
-            // intent contract checks that the received amount is sufficient, so
-            // we can simply transfer the balance.
-            uint256 n = intent.bridgeTokenOutOptions.length;
-            for (uint256 i = 0; i < n; ++i) {
-                TokenAmount calldata tokenOut = intent.bridgeTokenOutOptions[i];
+            // Otherwise, the relayer fastFinished the intent. Repay them.
+            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
                 TokenUtils.transferBalance({
-                    token: tokenOut.token,
+                    token: tokens[i],
                     recipient: payable(recipient)
                 });
             }
@@ -213,7 +269,7 @@ contract DaimoPay is ReentrancyGuard {
     /// if the intent has already been claimed.
     function refundIntent(
         PayIntent calldata intent,
-        IERC20 token
+        IERC20[] calldata tokens
     ) public nonReentrant {
         PayIntentContract intentContract = intentFactory.createIntent(intent);
         address intentAddr = address(intentContract);
@@ -227,16 +283,26 @@ contract DaimoPay is ReentrancyGuard {
             require(intentSent[intentAddr], "DP: not started");
         }
 
-        // Collect and refund overpaid amount.
-        uint256 amount = intentContract.refund(intent, token);
-        require(amount > 0, "DP: no funds to refund");
-        TokenUtils.transfer(token, payable(intent.refundAddress), amount);
+        // Collect tokens from intent contract.
+        uint256[] memory amounts = intentContract.sendToEscrow({
+            intent: intent,
+            tokens: tokens
+        });
+
+        // Refund tokens to the refund address
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            TokenUtils.transfer({
+                token: tokens[i],
+                recipient: payable(intent.refundAddress),
+                amount: amounts[i]
+            });
+        }
 
         emit IntentRefunded({
             intentAddr: intentAddr,
             refundAddr: intent.refundAddress,
-            token: address(token),
-            amount: amount,
+            tokens: tokens,
+            amounts: amounts,
             intent: intent
         });
     }
@@ -252,11 +318,7 @@ contract DaimoPay is ReentrancyGuard {
     ) internal {
         // Run arbitrary calls provided by the relayer. These will generally
         // approve the swap contract and swap if necessary.
-        for (uint256 i = 0; i < calls.length; ++i) {
-            Call calldata call = calls[i];
-            (bool callSuccess, ) = call.to.call{value: call.value}(call.data);
-            require(callSuccess, "DP: swap call failed");
-        }
+        _executeCalls(calls);
 
         // Check that the swap had a fair price
         uint256 finalCallTokenBalance = TokenUtils.getBalanceOf({
@@ -309,6 +371,34 @@ contract DaimoPay is ReentrancyGuard {
             token: intent.finalCallToken.token,
             recipient: payable(msg.sender)
         });
+    }
+
+    /// Check if the contract has enough balance for at least one of the bridge
+    /// token output options.
+    function _checkBridgeTokenOutBalance(
+        TokenAmount[] calldata bridgeTokenOutOptions
+    ) internal view returns (bool) {
+        uint256 n = bridgeTokenOutOptions.length;
+        bool balanceOk = false;
+        for (uint256 i = 0; i < n; ++i) {
+            TokenAmount calldata tokenOut = bridgeTokenOutOptions[i];
+            uint256 balance = tokenOut.token.balanceOf(address(this));
+            if (balance >= tokenOut.amount) {
+                balanceOk = true;
+                break;
+            }
+        }
+        return balanceOk;
+    }
+
+    /// Execute arbitrary calls. Revert if any fail.
+    function _executeCalls(Call[] calldata calls) internal {
+        uint256 n = calls.length;
+        for (uint256 i = 0; i < n; ++i) {
+            Call calldata call = calls[i];
+            (bool success, ) = call.to.call{value: call.value}(call.data);
+            require(success, "DP: call failed");
+        }
     }
 
     receive() external payable {}

--- a/packages/contract/src/DaimoPay.sol
+++ b/packages/contract/src/DaimoPay.sol
@@ -26,9 +26,9 @@ import "./TokenUtils.sol";
 /// @author Daimo, Inc
 /// @custom:security-contact security@daimo.com
 /// @notice Enables fast cross-chain transfers with optimistic intents.
-/// WARNING: Never approve tokens directly to this contract. Never
-/// transfer tokens to this contract as a standalone transaction.
-/// Such tokens can be stolen by anyone. Instead:
+/// WARNING: Never approve tokens directly to this contract. Never transfer
+/// tokens to this contract as a standalone transaction. Such tokens can be
+/// stolen by anyone. Instead:
 /// - Users should only interact by sending funds to an intent address.
 /// - Relayers should transfer funds and call this contract atomically via their
 ///   own contracts.
@@ -108,6 +108,11 @@ contract DaimoPay is ReentrancyGuard {
         // Ensure we don't reuse a nonce in the case where Alice is sending to
         // same destination with the same nonce multiple times.
         require(!intentSent[address(intentContract)], "DP: already sent");
+        // Can't call startIntent if the intent has already been claimed.
+        require(
+            intentToRecipient[address(intentContract)] != ADDR_MAX,
+            "DP: already claimed"
+        );
         // Mark the intent as sent
         intentSent[address(intentContract)] = true;
 
@@ -299,8 +304,7 @@ contract DaimoPay is ReentrancyGuard {
             require(intentSent[intentAddr], "DP: not started");
         }
 
-        // Collect tokens from intent contract and refund them to the refund
-        // address.
+        // Send tokens directly from intent contract to the refund address.
         uint256[] memory amounts = intentContract.sendTokens({
             intent: intent,
             tokens: tokens,

--- a/packages/contract/src/DaimoPay.sol
+++ b/packages/contract/src/DaimoPay.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.12;
 
-import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 
 import "./DaimoPayBridger.sol";
+import "./DaimoPayExecutioner.sol";
 import "./PayIntentFactory.sol";
 import "./TokenUtils.sol";
 
@@ -49,6 +49,9 @@ contract DaimoPay is ReentrancyGuard {
 
     /// Efficiently generates + deploys CREATE2 intent addresses.
     PayIntentFactory public immutable intentFactory;
+    /// Contract that executes arbitrary contract calls on behalf of the
+    /// DaimoPay escrow contract.
+    DaimoPayExecutioner public immutable executioner;
 
     /// On the source chain, record intents that have been sent.
     mapping(address intentAddr => bool) public intentSent;
@@ -88,8 +91,12 @@ contract DaimoPay is ReentrancyGuard {
         PayIntent intent
     );
 
-    constructor(PayIntentFactory _intentFactory) {
+    constructor(
+        PayIntentFactory _intentFactory,
+        DaimoPayExecutioner _executioner
+    ) {
         intentFactory = _intentFactory;
+        executioner = _executioner;
     }
 
     /// Starts an intent, bridging to the destination chain if necessary.
@@ -104,31 +111,32 @@ contract DaimoPay is ReentrancyGuard {
         // Ensure we don't reuse a nonce in the case where Alice is sending to
         // same destination with the same nonce multiple times.
         require(!intentSent[address(intentContract)], "DP: already sent");
+        // Mark the intent as sent
         intentSent[address(intentContract)] = true;
 
-        // Transfer from intent contract to this contract
-        intentContract.sendToEscrow({intent: intent, tokens: paymentTokens});
-
-        // Run arbitrary calls provided by the relayer. These will generally
-        // approve the swap contract and swap if necessary.
-        _executeCalls(calls);
+        // Transfer from intent contract to the executioner contract to run
+        // relayer-provided calls.
+        intentContract.sendTokens({
+            intent: intent,
+            tokens: paymentTokens,
+            recipient: payable(address(executioner))
+        });
 
         if (intent.toChainId == block.chainid) {
-            // Same chain. Check that the relayer calls produced enough output
-            // tokens.
-            bool balanceOk = _checkBridgeTokenOutBalance(
-                intent.bridgeTokenOutOptions
-            );
-            require(balanceOk, "PI: insufficient token");
+            // Same chain. Swap the tokens to one of the bridgeTokenOutOptions
+            // and send them back to the intent contract for later claimIntent.
 
-            // Send tokens to the intent address for later claimIntent.
-            uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
-            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
-                TokenUtils.transferBalance({
-                    token: intent.bridgeTokenOutOptions[i].token,
-                    recipient: payable(address(intentContract))
-                });
-            }
+            // Run arbitrary calls provided by the relayer. These will generally
+            // approve the swap contract and swap if necessary.
+            // The executioner contract checks that at least one of the
+            // bridgeTokenOutOptions is present.
+            executioner.execute({
+                calls: calls,
+                expectedOutput: intent.bridgeTokenOutOptions,
+                recipient: payable(address(intentContract))
+            });
+
+            // TODO: transfer surplus tokens to the caller
         } else {
             // Different chains. Get the input token and amount required to
             // initiate bridging
@@ -139,10 +147,19 @@ contract DaimoPay is ReentrancyGuard {
                     bridgeTokenOutOptions: intent.bridgeTokenOutOptions
                 });
 
-            // Check that the swap produced sufficient tokens to initiate
-            // bridging.
-            uint256 balance = IERC20(bridgeTokenIn).balanceOf(address(this));
-            require(balance >= inAmount, "PI: insufficient bridge token");
+            // Run arbitrary calls provided by the relayer. These will generally
+            // approve the swap contract and swap if necessary.
+            // The executioner contract checks that the output is sufficient.
+            TokenAmount[] memory expectedOutput = new TokenAmount[](1);
+            expectedOutput[0] = TokenAmount({
+                token: IERC20(bridgeTokenIn),
+                amount: inAmount
+            });
+            executioner.execute({
+                calls: calls,
+                expectedOutput: expectedOutput,
+                recipient: payable(address(this))
+            });
 
             // Approve bridger and initiate bridging
             IERC20(bridgeTokenIn).forceApprove({
@@ -178,7 +195,8 @@ contract DaimoPay is ReentrancyGuard {
     /// to claim the bridged tokens.
     function fastFinishIntent(
         PayIntent calldata intent,
-        Call[] calldata calls
+        Call[] calldata calls,
+        IERC20[] calldata tokens
     ) public nonReentrant {
         require(intent.toChainId == block.chainid, "DP: wrong chain");
 
@@ -191,9 +209,18 @@ contract DaimoPay is ReentrancyGuard {
             intentToRecipient[intentAddr] == address(0),
             "DP: already finished"
         );
-
         // Record relayer as new recipient when the bridged tokens arrive
         intentToRecipient[intentAddr] = msg.sender;
+
+        // Transfer tokens to the executioner contract to run relayer-provided
+        // calls in _finishIntent.
+        uint256 n = tokens.length;
+        for (uint256 i = 0; i < n; ++i) {
+            TokenUtils.transferBalance({
+                token: tokens[i],
+                recipient: payable(address(executioner))
+            });
+        }
 
         // Finish the intent and return any leftover tokens to the caller
         _finishIntent({intentAddr: intentAddr, intent: intent, calls: calls});
@@ -220,24 +247,22 @@ contract DaimoPay is ReentrancyGuard {
         // If intent is double-paid after it has already been claimed, then
         // the recipient should call refundIntent to get their funds back.
         require(recipient != ADDR_MAX, "DP: already claimed");
-
-        // Transfer from intent contract to this contract
-        uint256 tokenOptionsLength = intent.bridgeTokenOutOptions.length;
-        IERC20[] memory tokens = new IERC20[](tokenOptionsLength);
-        for (uint256 i = 0; i < tokenOptionsLength; ++i) {
-            tokens[i] = intent.bridgeTokenOutOptions[i].token;
-        }
-        intentContract.sendToEscrow({intent: intent, tokens: tokens});
-
-        // Check that enough tokens were received. Revert otherwise.
-        bool balanceOk = _checkBridgeTokenOutBalance(
-            intent.bridgeTokenOutOptions
-        );
-        require(balanceOk, "DP: insufficient token received");
+        // Mark intent as claimed
+        intentToRecipient[address(intentContract)] = ADDR_MAX;
 
         if (recipient == address(0)) {
             // No relayer showed up, so just complete the intent.
             recipient = intent.finalCall.to;
+
+            // Send tokens from the intent contract to the executioner contract
+            // to run relayer-provided calls in _finishIntent.
+            // The intent contract will check that sufficient bridge tokens
+            // were received.
+            intentContract.checkBalanceAndSendTokens({
+                intent: intent,
+                tokenAmounts: intent.bridgeTokenOutOptions,
+                recipient: payable(address(executioner))
+            });
 
             // Complete the intent and return any leftover tokens to the caller
             _finishIntent({
@@ -247,16 +272,14 @@ contract DaimoPay is ReentrancyGuard {
             });
         } else {
             // Otherwise, the relayer fastFinished the intent. Repay them.
-            for (uint256 i = 0; i < tokenOptionsLength; ++i) {
-                TokenUtils.transferBalance({
-                    token: tokens[i],
-                    recipient: payable(recipient)
-                });
-            }
+            // The intent contract will check that sufficient bridge tokens
+            // were received.
+            intentContract.checkBalanceAndSendTokens({
+                intent: intent,
+                tokenAmounts: intent.bridgeTokenOutOptions,
+                recipient: payable(recipient)
+            });
         }
-
-        // Mark as claimed
-        intentToRecipient[address(intentContract)] = ADDR_MAX;
 
         emit Claim({
             intentAddr: address(intentContract),
@@ -283,20 +306,13 @@ contract DaimoPay is ReentrancyGuard {
             require(intentSent[intentAddr], "DP: not started");
         }
 
-        // Collect tokens from intent contract.
-        uint256[] memory amounts = intentContract.sendToEscrow({
+        // Collect tokens from intent contract and refund them to the refund
+        // address.
+        uint256[] memory amounts = intentContract.sendTokens({
             intent: intent,
-            tokens: tokens
+            tokens: tokens,
+            recipient: payable(intent.refundAddress)
         });
-
-        // Refund tokens to the refund address
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            TokenUtils.transfer({
-                token: tokens[i],
-                recipient: payable(intent.refundAddress),
-                amount: amounts[i]
-            });
-        }
 
         emit IntentRefunded({
             intentAddr: intentAddr,
@@ -318,29 +334,21 @@ contract DaimoPay is ReentrancyGuard {
     ) internal {
         // Run arbitrary calls provided by the relayer. These will generally
         // approve the swap contract and swap if necessary.
-        _executeCalls(calls);
-
-        // Check that the swap had a fair price
-        uint256 finalCallTokenBalance = TokenUtils.getBalanceOf({
-            token: intent.finalCallToken.token,
-            addr: address(this)
+        TokenAmount[] memory expectedOutput = new TokenAmount[](1);
+        expectedOutput[0] = intent.finalCallToken;
+        executioner.execute({
+            calls: calls,
+            expectedOutput: expectedOutput,
+            recipient: payable(address(this))
         });
-        require(
-            finalCallTokenBalance >= intent.finalCallToken.amount,
-            "DP: insufficient final call token received"
-        );
 
         bool success;
         if (intent.finalCall.data.length > 0) {
             // If the intent is a call, approve the final token and make the call
-            TokenUtils.approve({
-                token: intent.finalCallToken.token,
-                spender: address(intent.finalCall.to),
-                amount: intent.finalCallToken.amount
+            success = executioner.executeFinalCall({
+                finalCall: intent.finalCall,
+                finalCallToken: intent.finalCallToken
             });
-            (success, ) = intent.finalCall.to.call{
-                value: intent.finalCall.value
-            }(intent.finalCall.data);
         } else {
             // If the final call is a transfer, transfer the token.
             success = TokenUtils.tryTransfer(
@@ -371,34 +379,6 @@ contract DaimoPay is ReentrancyGuard {
             token: intent.finalCallToken.token,
             recipient: payable(msg.sender)
         });
-    }
-
-    /// Check if the contract has enough balance for at least one of the bridge
-    /// token output options.
-    function _checkBridgeTokenOutBalance(
-        TokenAmount[] calldata bridgeTokenOutOptions
-    ) internal view returns (bool) {
-        uint256 n = bridgeTokenOutOptions.length;
-        bool balanceOk = false;
-        for (uint256 i = 0; i < n; ++i) {
-            TokenAmount calldata tokenOut = bridgeTokenOutOptions[i];
-            uint256 balance = tokenOut.token.balanceOf(address(this));
-            if (balance >= tokenOut.amount) {
-                balanceOk = true;
-                break;
-            }
-        }
-        return balanceOk;
-    }
-
-    /// Execute arbitrary calls. Revert if any fail.
-    function _executeCalls(Call[] calldata calls) internal {
-        uint256 n = calls.length;
-        for (uint256 i = 0; i < n; ++i) {
-            Call calldata call = calls[i];
-            (bool success, ) = call.to.call{value: call.value}(call.data);
-            require(success, "DP: call failed");
-        }
     }
 
     receive() external payable {}

--- a/packages/contract/src/DaimoPay.sol
+++ b/packages/contract/src/DaimoPay.sol
@@ -5,7 +5,7 @@ import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 
 import "./DaimoPayBridger.sol";
-import "./DaimoPayExecutioner.sol";
+import "./DaimoPayExecutor.sol";
 import "./PayIntentFactory.sol";
 import "./TokenUtils.sol";
 
@@ -51,7 +51,7 @@ contract DaimoPay is ReentrancyGuard {
     PayIntentFactory public immutable intentFactory;
     /// Contract that executes arbitrary contract calls on behalf of the
     /// DaimoPay escrow contract.
-    DaimoPayExecutioner public immutable executioner;
+    DaimoPayExecutor public immutable executor;
 
     /// On the source chain, record intents that have been sent.
     mapping(address intentAddr => bool) public intentSent;
@@ -91,12 +91,9 @@ contract DaimoPay is ReentrancyGuard {
         PayIntent intent
     );
 
-    constructor(
-        PayIntentFactory _intentFactory,
-        DaimoPayExecutioner _executioner
-    ) {
+    constructor(PayIntentFactory _intentFactory) {
         intentFactory = _intentFactory;
-        executioner = _executioner;
+        executor = new DaimoPayExecutor(address(this));
     }
 
     /// Starts an intent, bridging to the destination chain if necessary.
@@ -114,12 +111,12 @@ contract DaimoPay is ReentrancyGuard {
         // Mark the intent as sent
         intentSent[address(intentContract)] = true;
 
-        // Transfer from intent contract to the executioner contract to run
+        // Transfer from intent contract to the executor contract to run
         // relayer-provided calls.
         intentContract.sendTokens({
             intent: intent,
             tokens: paymentTokens,
-            recipient: payable(address(executioner))
+            recipient: payable(address(executor))
         });
 
         if (intent.toChainId == block.chainid) {
@@ -128,15 +125,15 @@ contract DaimoPay is ReentrancyGuard {
 
             // Run arbitrary calls provided by the relayer. These will generally
             // approve the swap contract and swap if necessary.
-            // The executioner contract checks that at least one of the
-            // bridgeTokenOutOptions is present.
-            executioner.execute({
+            // The executor contract checks that at least one of the
+            // bridgeTokenOutOptions is present. Any surplus tokens are given
+            // to the caller.
+            executor.execute({
                 calls: calls,
                 expectedOutput: intent.bridgeTokenOutOptions,
-                recipient: payable(address(intentContract))
+                recipient: payable(address(intentContract)),
+                surplusRecipient: payable(msg.sender)
             });
-
-            // TODO: transfer surplus tokens to the caller
         } else {
             // Different chains. Get the input token and amount required to
             // initiate bridging
@@ -149,16 +146,18 @@ contract DaimoPay is ReentrancyGuard {
 
             // Run arbitrary calls provided by the relayer. These will generally
             // approve the swap contract and swap if necessary.
-            // The executioner contract checks that the output is sufficient.
+            // The executor contract checks that the output is sufficient. Any
+            // surplus tokens are given to the caller.
             TokenAmount[] memory expectedOutput = new TokenAmount[](1);
             expectedOutput[0] = TokenAmount({
                 token: IERC20(bridgeTokenIn),
                 amount: inAmount
             });
-            executioner.execute({
+            executor.execute({
                 calls: calls,
                 expectedOutput: expectedOutput,
-                recipient: payable(address(this))
+                recipient: payable(address(this)),
+                surplusRecipient: payable(msg.sender)
             });
 
             // Approve bridger and initiate bridging
@@ -171,12 +170,6 @@ contract DaimoPay is ReentrancyGuard {
                 toAddress: address(intentContract),
                 bridgeTokenOutOptions: intent.bridgeTokenOutOptions,
                 extraData: bridgeExtraData
-            });
-
-            // Refund any leftover tokens in the contract to the caller
-            TokenUtils.transferBalance({
-                token: IERC20(bridgeTokenIn),
-                recipient: payable(msg.sender)
             });
         }
 
@@ -212,13 +205,13 @@ contract DaimoPay is ReentrancyGuard {
         // Record relayer as new recipient when the bridged tokens arrive
         intentToRecipient[intentAddr] = msg.sender;
 
-        // Transfer tokens to the executioner contract to run relayer-provided
+        // Transfer tokens to the executor contract to run relayer-provided
         // calls in _finishIntent.
         uint256 n = tokens.length;
         for (uint256 i = 0; i < n; ++i) {
             TokenUtils.transferBalance({
                 token: tokens[i],
-                recipient: payable(address(executioner))
+                recipient: payable(address(executor))
             });
         }
 
@@ -254,14 +247,14 @@ contract DaimoPay is ReentrancyGuard {
             // No relayer showed up, so just complete the intent.
             recipient = intent.finalCall.to;
 
-            // Send tokens from the intent contract to the executioner contract
+            // Send tokens from the intent contract to the executor contract
             // to run relayer-provided calls in _finishIntent.
             // The intent contract will check that sufficient bridge tokens
             // were received.
             intentContract.checkBalanceAndSendTokens({
                 intent: intent,
                 tokenAmounts: intent.bridgeTokenOutOptions,
-                recipient: payable(address(executioner))
+                recipient: payable(address(executor))
             });
 
             // Complete the intent and return any leftover tokens to the caller
@@ -326,26 +319,30 @@ contract DaimoPay is ReentrancyGuard {
     /// Execute the calls provided by the relayer and check that there is
     /// sufficient finalCallToken. Then, if the intent has a finalCall, make
     /// the intent call. Otherwise, transfer the token to the final address.
-    /// Finally, send any leftover final token to the caller.
+    /// Any surplus tokens are given to the caller.
+    /// This function assumes that tokens are already transferred to the
+    /// executor contract before being called.
     function _finishIntent(
         address intentAddr,
         PayIntent calldata intent,
         Call[] calldata calls
     ) internal {
         // Run arbitrary calls provided by the relayer. These will generally
-        // approve the swap contract and swap if necessary.
-        TokenAmount[] memory expectedOutput = new TokenAmount[](1);
-        expectedOutput[0] = intent.finalCallToken;
-        executioner.execute({
+        // approve the swap contract and swap if necessary. Any surplus tokens
+        // are given to the caller.
+        TokenAmount[] memory finalCallAmount = new TokenAmount[](1);
+        finalCallAmount[0] = intent.finalCallToken;
+        executor.execute({
             calls: calls,
-            expectedOutput: expectedOutput,
-            recipient: payable(address(this))
+            expectedOutput: finalCallAmount,
+            recipient: payable(address(this)),
+            surplusRecipient: payable(msg.sender)
         });
 
         bool success;
         if (intent.finalCall.data.length > 0) {
             // If the intent is a call, approve the final token and make the call
-            success = executioner.executeFinalCall({
+            success = executor.executeFinalCall({
                 finalCall: intent.finalCall,
                 finalCallToken: intent.finalCallToken
             });
@@ -372,12 +369,6 @@ contract DaimoPay is ReentrancyGuard {
             destinationAddr: intent.finalCall.to,
             success: success,
             intent: intent
-        });
-
-        // Send any leftover final token to the caller
-        TokenUtils.transferBalance({
-            token: intent.finalCallToken.token,
-            recipient: payable(msg.sender)
         });
     }
 

--- a/packages/contract/src/DaimoPayExecutioner.sol
+++ b/packages/contract/src/DaimoPayExecutioner.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.12;
+
+import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+
+import "./TokenUtils.sol";
+
+/// Represents a contract call.
+struct Call {
+    /// Address of the contract to call.
+    address to;
+    /// Native token amount for call, or 0
+    uint256 value;
+    /// Calldata for call
+    bytes data;
+}
+
+/// @author Daimo, Inc
+/// @custom:security-contact security@daimo.com
+/// @notice This contract is used to execute arbitrary contract calls on behalf
+/// of the DaimoPay escrow contract.
+contract DaimoPayExecutioner is Initializable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /// The only address that is allowed to call the `execute` function.
+    address payable public escrow;
+
+    constructor() {}
+
+    function initialize(address payable _escrow) public initializer {
+        escrow = _escrow;
+    }
+
+    /// Execute arbitrary calls. Revert if any fail.
+    /// Check that at least one of the expectedOutput tokens is present.
+    /// Transfer the full balance of each expectedOutput token to the escrow.
+    function execute(
+        Call[] calldata calls,
+        TokenAmount[] calldata expectedOutput,
+        address payable recipient
+    ) external nonReentrant {
+        require(msg.sender == escrow, "DPCE: only escrow");
+
+        uint256 callsLength = calls.length;
+        for (uint256 i = 0; i < callsLength; ++i) {
+            Call calldata call = calls[i];
+            (bool success, ) = call.to.call{value: call.value}(call.data);
+            require(success, "DPCE: call failed");
+        }
+
+        /// Check that at least one of the expectedOutput tokens is present
+        /// with enough balance.
+        bool outputOk = TokenUtils.checkBalance({tokenAmounts: expectedOutput});
+        require(outputOk, "DPCE: insufficient output");
+
+        uint256 expectedOutputLength = expectedOutput.length;
+        for (uint256 i = 0; i < expectedOutputLength; ++i) {
+            TokenUtils.transferBalance({
+                token: expectedOutput[i].token,
+                recipient: recipient
+            });
+        }
+    }
+
+    /// Execute a final call. Approve the final token and make the call.
+    /// Return whether the call succeeded.
+    function executeFinalCall(
+        Call calldata finalCall,
+        TokenAmount calldata finalCallToken
+    ) external nonReentrant returns (bool success) {
+        require(msg.sender == escrow, "DPCE: only escrow");
+
+        TokenUtils.approve({
+            token: finalCallToken.token,
+            spender: address(finalCall.to),
+            amount: finalCallToken.amount
+        });
+
+        (success, ) = finalCall.to.call{value: finalCall.value}(finalCall.data);
+    }
+
+    /// Accept native-token (eg ETH) inputs
+    receive() external payable {}
+}

--- a/packages/contract/src/DaimoPayExecutor.sol
+++ b/packages/contract/src/DaimoPayExecutor.sol
@@ -21,25 +21,25 @@ struct Call {
 /// @custom:security-contact security@daimo.com
 /// @notice This contract is used to execute arbitrary contract calls on behalf
 /// of the DaimoPay escrow contract.
-contract DaimoPayExecutioner is Initializable, ReentrancyGuard {
+contract DaimoPayExecutor is Initializable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /// The only address that is allowed to call the `execute` function.
-    address payable public escrow;
+    address public immutable escrow;
 
-    constructor() {}
-
-    function initialize(address payable _escrow) public initializer {
+    constructor(address _escrow) {
         escrow = _escrow;
     }
 
     /// Execute arbitrary calls. Revert if any fail.
-    /// Check that at least one of the expectedOutput tokens is present.
-    /// Transfer the full balance of each expectedOutput token to the escrow.
+    /// Check that at least one of the expectedOutput tokens is present. Assumes
+    /// that exactly one token is present as transfers it to the recipient.
+    /// Returns any surplus tokens to the surplus recipient.
     function execute(
         Call[] calldata calls,
         TokenAmount[] calldata expectedOutput,
-        address payable recipient
+        address payable recipient,
+        address payable surplusRecipient
     ) external nonReentrant {
         require(msg.sender == escrow, "DPCE: only escrow");
 
@@ -52,16 +52,20 @@ contract DaimoPayExecutioner is Initializable, ReentrancyGuard {
 
         /// Check that at least one of the expectedOutput tokens is present
         /// with enough balance.
-        bool outputOk = TokenUtils.checkBalance({tokenAmounts: expectedOutput});
-        require(outputOk, "DPCE: insufficient output");
+        (IERC20 token, uint256 amount) = TokenUtils.checkBalance({
+            tokenAmounts: expectedOutput
+        });
+        require(amount > 0, "DPCE: insufficient output");
 
-        uint256 expectedOutputLength = expectedOutput.length;
-        for (uint256 i = 0; i < expectedOutputLength; ++i) {
-            TokenUtils.transferBalance({
-                token: expectedOutput[i].token,
-                recipient: recipient
-            });
-        }
+        // Transfer the expected amount of the token to the recipient.
+        TokenUtils.transfer({
+            token: token,
+            recipient: recipient,
+            amount: amount
+        });
+
+        // Transfer any surplus tokens to the surplus recipient.
+        TokenUtils.transferBalance({token: token, recipient: surplusRecipient});
     }
 
     /// Execute a final call. Approve the final token and make the call.

--- a/packages/contract/src/DaimoPayExecutor.sol
+++ b/packages/contract/src/DaimoPayExecutor.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.12;
 
-import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 
@@ -21,7 +20,10 @@ struct Call {
 /// @custom:security-contact security@daimo.com
 /// @notice This contract is used to execute arbitrary contract calls on behalf
 /// of the DaimoPay escrow contract.
-contract DaimoPayExecutor is Initializable, ReentrancyGuard {
+/// WARNING: Never approve tokens directly to this contract. Never transfer
+/// tokens to this contract. Such tokens can be stolen by anyone. All
+/// interactions with this contract should be done via the DaimoPay contract.
+contract DaimoPayExecutor is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /// The only address that is allowed to call the `execute` function.
@@ -33,7 +35,7 @@ contract DaimoPayExecutor is Initializable, ReentrancyGuard {
 
     /// Execute arbitrary calls. Revert if any fail.
     /// Check that at least one of the expectedOutput tokens is present. Assumes
-    /// that exactly one token is present as transfers it to the recipient.
+    /// that exactly one token is present and transfers it to the recipient.
     /// Returns any surplus tokens to the surplus recipient.
     function execute(
         Call[] calldata calls,
@@ -43,6 +45,7 @@ contract DaimoPayExecutor is Initializable, ReentrancyGuard {
     ) external nonReentrant {
         require(msg.sender == escrow, "DPCE: only escrow");
 
+        // Execute provided calls.
         uint256 callsLength = calls.length;
         for (uint256 i = 0; i < callsLength; ++i) {
             Call calldata call = calls[i];
@@ -52,20 +55,26 @@ contract DaimoPayExecutor is Initializable, ReentrancyGuard {
 
         /// Check that at least one of the expectedOutput tokens is present
         /// with enough balance.
-        (IERC20 token, uint256 amount) = TokenUtils.checkBalance({
+        uint256 outputIndex = TokenUtils.checkBalance({
             tokenAmounts: expectedOutput
         });
-        require(amount > 0, "DPCE: insufficient output");
+        require(
+            outputIndex < expectedOutput.length,
+            "DPCE: insufficient output"
+        );
 
         // Transfer the expected amount of the token to the recipient.
         TokenUtils.transfer({
-            token: token,
+            token: expectedOutput[outputIndex].token,
             recipient: recipient,
-            amount: amount
+            amount: expectedOutput[outputIndex].amount
         });
 
         // Transfer any surplus tokens to the surplus recipient.
-        TokenUtils.transferBalance({token: token, recipient: surplusRecipient});
+        TokenUtils.transferBalance({
+            token: expectedOutput[outputIndex].token,
+            recipient: surplusRecipient
+        });
     }
 
     /// Execute a final call. Approve the final token and make the call.
@@ -76,12 +85,14 @@ contract DaimoPayExecutor is Initializable, ReentrancyGuard {
     ) external nonReentrant returns (bool success) {
         require(msg.sender == escrow, "DPCE: only escrow");
 
+        // Approve the final call token to the final call contract.
         TokenUtils.approve({
             token: finalCallToken.token,
             spender: address(finalCall.to),
             amount: finalCallToken.amount
         });
 
+        // Then, execute the final call.
         (success, ) = finalCall.to.call{value: finalCall.value}(finalCall.data);
     }
 

--- a/packages/contract/src/PayIntent.sol
+++ b/packages/contract/src/PayIntent.sol
@@ -5,7 +5,7 @@ import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 
-import {Call} from "./DaimoPayExecutioner.sol";
+import {Call} from "./DaimoPayExecutor.sol";
 import "./TokenUtils.sol";
 import "./interfaces/IDaimoPayBridger.sol";
 
@@ -81,27 +81,28 @@ contract PayIntentContract is Initializable, ReentrancyGuard {
         }
     }
 
-    /// Check that at least one of the token amounts is present, then send the
-    /// tokens to a recipient.
+    /// Check that at least one of the token amounts is present. Assumes exactly
+    /// one token is present, then sends the token to a recipient.
     function checkBalanceAndSendTokens(
         PayIntent calldata intent,
         TokenAmount[] calldata tokenAmounts,
         address payable recipient
-    ) public nonReentrant returns (uint256[] memory amounts) {
+    ) public nonReentrant {
         require(calcIntentHash(intent) == intentHash, "PI: intent");
         require(msg.sender == intent.escrow, "PI: only escrow");
 
-        bool balanceOk = TokenUtils.checkBalance({tokenAmounts: tokenAmounts});
-        require(balanceOk, "PI: insufficient balance");
+        // Check that at least one of the token amounts is present.
+        (IERC20 token, uint256 amount) = TokenUtils.checkBalance({
+            tokenAmounts: tokenAmounts
+        });
+        require(amount > 0, "PI: insufficient balance");
 
-        uint256 n = tokenAmounts.length;
-        amounts = new uint256[](n);
-        for (uint256 i = 0; i < n; ++i) {
-            amounts[i] = TokenUtils.transferBalance({
-                token: tokenAmounts[i].token,
-                recipient: recipient
-            });
-        }
+        // Transfer the token amount to the recipient.
+        TokenUtils.transfer({
+            token: token,
+            recipient: recipient,
+            amount: amount
+        });
     }
 
     /// Accept native-token (eg ETH) inputs

--- a/packages/contract/src/PayIntent.sol
+++ b/packages/contract/src/PayIntent.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.12;
 import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+
+import {Call} from "./DaimoPayExecutioner.sol";
 import "./TokenUtils.sol";
 import "./interfaces/IDaimoPayBridger.sol";
 
@@ -17,9 +19,10 @@ struct PayIntent {
     TokenAmount[] bridgeTokenOutOptions;
     /// Expected token amount after swapping on the destination chain.
     TokenAmount finalCallToken;
-    /// If finalCall.data is empty, the tokens are transferred to finalCall.to.
-    /// Otherwise, (token, amount) is approved to finalCall.to and finalCall.to
-    /// is called with finalCall.data and finalCall.value.
+    /// Contract call to execute on the destination chain. If finalCall.data is
+    /// empty, the tokens are transferred to finalCall.to. Otherwise, (token,
+    /// amount) is approved to finalCall.to and finalCall.to is called with
+    /// finalCall.data and finalCall.value.
     Call finalCall;
     /// Escrow contract. All calls are made through this contract.
     address payable escrow;
@@ -58,21 +61,45 @@ contract PayIntentContract is Initializable, ReentrancyGuard {
         intentHash = _intentHash;
     }
 
-    /// Send funds to the escrow contract for processing.
-    function sendToEscrow(
+    /// Send tokens to a recipient.
+    function sendTokens(
         PayIntent calldata intent,
-        IERC20[] calldata tokens
+        IERC20[] calldata tokens,
+        address payable recipient
     ) public nonReentrant returns (uint256[] memory amounts) {
         require(calcIntentHash(intent) == intentHash, "PI: intent");
         require(msg.sender == intent.escrow, "PI: only escrow");
 
         uint256 n = tokens.length;
         amounts = new uint256[](n);
-        // Send tokens to escrow contract
+        // Send tokens to recipient
         for (uint256 i = 0; i < n; ++i) {
             amounts[i] = TokenUtils.transferBalance({
                 token: tokens[i],
-                recipient: intent.escrow
+                recipient: recipient
+            });
+        }
+    }
+
+    /// Check that at least one of the token amounts is present, then send the
+    /// tokens to a recipient.
+    function checkBalanceAndSendTokens(
+        PayIntent calldata intent,
+        TokenAmount[] calldata tokenAmounts,
+        address payable recipient
+    ) public nonReentrant returns (uint256[] memory amounts) {
+        require(calcIntentHash(intent) == intentHash, "PI: intent");
+        require(msg.sender == intent.escrow, "PI: only escrow");
+
+        bool balanceOk = TokenUtils.checkBalance({tokenAmounts: tokenAmounts});
+        require(balanceOk, "PI: insufficient balance");
+
+        uint256 n = tokenAmounts.length;
+        amounts = new uint256[](n);
+        for (uint256 i = 0; i < n; ++i) {
+            amounts[i] = TokenUtils.transferBalance({
+                token: tokenAmounts[i].token,
+                recipient: recipient
             });
         }
     }

--- a/packages/contract/src/PayIntent.sol
+++ b/packages/contract/src/PayIntent.sol
@@ -58,117 +58,23 @@ contract PayIntentContract is Initializable, ReentrancyGuard {
         intentHash = _intentHash;
     }
 
-    /// Check if the contract has enough balance for at least one of the bridge
-    /// token output options.
-    function checkBridgeTokenOutBalance(
-        TokenAmount[] calldata bridgeTokenOutOptions
-    ) public view returns (bool) {
-        bool balanceOk = false;
-        for (uint256 i = 0; i < bridgeTokenOutOptions.length; ++i) {
-            TokenAmount calldata tokenOut = bridgeTokenOutOptions[i];
-            uint256 balance = tokenOut.token.balanceOf(address(this));
-            if (balance >= tokenOut.amount) {
-                balanceOk = true;
-                break;
-            }
-        }
-        return balanceOk;
-    }
-
-    /// Called on the source chain to start the intent. Run the calls specified
-    /// by the relayer, then send funds to the bridger for cross-chain intents.
-    function start(
+    /// Send funds to the escrow contract for processing.
+    function sendToEscrow(
         PayIntent calldata intent,
-        address payable caller,
-        Call[] calldata calls,
-        bytes calldata bridgeExtraData
-    ) public nonReentrant {
+        IERC20[] calldata tokens
+    ) public nonReentrant returns (uint256[] memory amounts) {
         require(calcIntentHash(intent) == intentHash, "PI: intent");
         require(msg.sender == intent.escrow, "PI: only escrow");
 
-        // Run arbitrary calls provided by the relayer. These will generally
-        // approve the swap contract and swap if necessary.
-        for (uint256 i = 0; i < calls.length; ++i) {
-            Call calldata call = calls[i];
-            (bool success, ) = call.to.call{value: call.value}(call.data);
-            require(success, "PI: swap call failed");
-        }
-
-        if (intent.toChainId == block.chainid) {
-            // Same chain. Check that the contract has sufficient token balance.
-            bool balanceOk = checkBridgeTokenOutBalance(
-                intent.bridgeTokenOutOptions
-            );
-            require(balanceOk, "PI: insufficient token");
-        } else {
-            // Different chains. Get the input token and amount required to
-            // initiate bridging
-            IDaimoPayBridger bridger = intent.bridger;
-            (address bridgeTokenIn, uint256 inAmount) = bridger
-                .getBridgeTokenIn({
-                    toChainId: intent.toChainId,
-                    bridgeTokenOutOptions: intent.bridgeTokenOutOptions
-                });
-
-            uint256 balance = IERC20(bridgeTokenIn).balanceOf(address(this));
-            require(balance >= inAmount, "PI: insufficient bridge token");
-
-            // Approve bridger and initiate bridging
-            IERC20(bridgeTokenIn).forceApprove({
-                spender: address(bridger),
-                value: inAmount
-            });
-            bridger.sendToChain({
-                toChainId: intent.toChainId,
-                toAddress: address(this),
-                bridgeTokenOutOptions: intent.bridgeTokenOutOptions,
-                extraData: bridgeExtraData
-            });
-
-            // Refund any leftover tokens in the contract to the caller
-            TokenUtils.transferBalance({
-                token: IERC20(bridgeTokenIn),
-                recipient: caller
-            });
-        }
-    }
-
-    /// Check that there is sufficient output token and send tokens to the
-    /// escrow contract.
-    function claim(PayIntent calldata intent) public nonReentrant {
-        require(keccak256(abi.encode(intent)) == intentHash, "PI: intent");
-        require(msg.sender == intent.escrow, "PI: only escrow");
-        require(block.chainid == intent.toChainId, "PI: only dest chain");
-
-        bool balanceOk = checkBridgeTokenOutBalance(
-            intent.bridgeTokenOutOptions
-        );
-        require(balanceOk, "PI: insufficient token received");
-
-        // Send to escrow contract, which will forward to current recipient
-        uint256 n = intent.bridgeTokenOutOptions.length;
+        uint256 n = tokens.length;
+        amounts = new uint256[](n);
+        // Send tokens to escrow contract
         for (uint256 i = 0; i < n; ++i) {
-            TokenUtils.transferBalance({
-                token: intent.bridgeTokenOutOptions[i].token,
+            amounts[i] = TokenUtils.transferBalance({
+                token: tokens[i],
                 recipient: intent.escrow
             });
         }
-    }
-
-    /// Refund double payments.
-    function refund(
-        PayIntent calldata intent,
-        IERC20 token
-    ) public nonReentrant returns (uint256 amount) {
-        require(calcIntentHash(intent) == intentHash, "PI: intent");
-        require(msg.sender == intent.escrow, "PI: only escrow");
-
-        // Send to escrow contract, which will forward to the refund address.
-        amount = TokenUtils.transferBalance({
-            token: token,
-            recipient: intent.escrow
-        });
-        require(amount > 0, "PI: no funds to refund");
     }
 
     /// Accept native-token (eg ETH) inputs

--- a/packages/contract/src/PayIntent.sol
+++ b/packages/contract/src/PayIntent.sol
@@ -92,16 +92,16 @@ contract PayIntentContract is Initializable, ReentrancyGuard {
         require(msg.sender == intent.escrow, "PI: only escrow");
 
         // Check that at least one of the token amounts is present.
-        (IERC20 token, uint256 amount) = TokenUtils.checkBalance({
+        uint256 tokenIndex = TokenUtils.checkBalance({
             tokenAmounts: tokenAmounts
         });
-        require(amount > 0, "PI: insufficient balance");
+        require(tokenIndex < tokenAmounts.length, "PI: insufficient balance");
 
         // Transfer the token amount to the recipient.
         TokenUtils.transfer({
-            token: token,
+            token: tokenAmounts[tokenIndex].token,
             recipient: recipient,
-            amount: amount
+            amount: tokenAmounts[tokenIndex].amount
         });
     }
 

--- a/packages/contract/src/TokenUtils.sol
+++ b/packages/contract/src/TokenUtils.sol
@@ -90,11 +90,11 @@ library TokenUtils {
     }
 
     /// Check that the address has enough of at least one of the tokenAmounts.
-    /// Returns the address and expected amount (not the balance!) of the first
-    /// token that has sufficient balance.
+    /// Returns the index of the first token that has sufficient balance, or
+    /// the length of the tokenAmounts array if no token has sufficient balance.
     function checkBalance(
         TokenAmount[] calldata tokenAmounts
-    ) internal view returns (IERC20 token, uint256 amount) {
+    ) internal view returns (uint256) {
         uint256 n = tokenAmounts.length;
         for (uint256 i = 0; i < n; ++i) {
             TokenAmount calldata tokenAmount = tokenAmounts[i];
@@ -103,9 +103,9 @@ library TokenUtils {
                 addr: address(this)
             });
             if (balance >= tokenAmount.amount) {
-                return (tokenAmount.token, tokenAmount.amount);
+                return i;
             }
         }
-        return (IERC20(address(0)), 0);
+        return n;
     }
 }

--- a/packages/contract/src/TokenUtils.sol
+++ b/packages/contract/src/TokenUtils.sol
@@ -11,16 +11,6 @@ struct TokenAmount {
     uint256 amount;
 }
 
-/// Represents a destination address + optional arbitrary contract call
-struct Call {
-    /// Destination receiving address or contract
-    address to;
-    /// Native token amount for call, or 0
-    uint256 value;
-    /// Calldata for call, or empty = no contract call
-    bytes data;
-}
-
 /// Utility functions that work for both ERC20 and native tokens.
 library TokenUtils {
     using SafeERC20 for IERC20;
@@ -97,5 +87,23 @@ library TokenUtils {
             transfer({token: token, recipient: recipient, amount: balance});
         }
         return balance;
+    }
+
+    /// Check that the address has enough of at least one of the tokenAmounts.
+    function checkBalance(
+        TokenAmount[] calldata tokenAmounts
+    ) internal view returns (bool) {
+        uint256 n = tokenAmounts.length;
+        for (uint256 i = 0; i < n; ++i) {
+            TokenAmount calldata tokenAmount = tokenAmounts[i];
+            uint256 balance = getBalanceOf({
+                token: tokenAmount.token,
+                addr: address(this)
+            });
+            if (balance >= tokenAmount.amount) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/packages/contract/src/TokenUtils.sol
+++ b/packages/contract/src/TokenUtils.sol
@@ -30,7 +30,7 @@ library TokenUtils {
     /// Approves a token transfer.
     function approve(IERC20 token, address spender, uint256 amount) internal {
         if (address(token) != address(0)) {
-            token.approve({spender: spender, value: amount});
+            token.forceApprove({spender: spender, value: amount});
         } // Do nothing for native token.
     }
 
@@ -90,9 +90,11 @@ library TokenUtils {
     }
 
     /// Check that the address has enough of at least one of the tokenAmounts.
+    /// Returns the address and expected amount (not the balance!) of the first
+    /// token that has sufficient balance.
     function checkBalance(
         TokenAmount[] calldata tokenAmounts
-    ) internal view returns (bool) {
+    ) internal view returns (IERC20 token, uint256 amount) {
         uint256 n = tokenAmounts.length;
         for (uint256 i = 0; i < n; ++i) {
             TokenAmount calldata tokenAmount = tokenAmounts[i];
@@ -101,9 +103,9 @@ library TokenUtils {
                 addr: address(this)
             });
             if (balance >= tokenAmount.amount) {
-                return true;
+                return (tokenAmount.token, tokenAmount.amount);
             }
         }
-        return false;
+        return (IERC20(address(0)), 0);
     }
 }

--- a/packages/contract/src/relayer/DaimoPayRelayer.sol
+++ b/packages/contract/src/relayer/DaimoPayRelayer.sol
@@ -228,7 +228,10 @@ contract DaimoPayRelayer is AccessControl {
             recipient: payable(address(dp)),
             amount: tokenIn.amount
         });
-        dp.fastFinishIntent(intent, calls);
+
+        IERC20[] memory tokens = new IERC20[](1);
+        tokens[0] = tokenIn.token;
+        dp.fastFinishIntent({intent: intent, calls: calls, tokens: tokens});
     }
 
     function claimAndKeep(

--- a/packages/contract/src/relayer/DaimoPayRelayer.sol
+++ b/packages/contract/src/relayer/DaimoPayRelayer.sol
@@ -190,6 +190,7 @@ contract DaimoPayRelayer is AccessControl {
         Call[] calldata preCalls,
         DaimoPay dp,
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata startCalls,
         bytes calldata bridgeExtraData,
         Call[] calldata postCalls
@@ -203,6 +204,7 @@ contract DaimoPayRelayer is AccessControl {
 
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: startCalls,
             bridgeExtraData: bridgeExtraData
         });

--- a/packages/contract/test/DaimoPay.t.sol
+++ b/packages/contract/test/DaimoPay.t.sol
@@ -1391,9 +1391,6 @@ contract DaimoPayTest is Test {
         address victimIntentAddress = intentFactory.getIntentAddress(
             victimIntent
         );
-        address maliciousIntentAddress = intentFactory.getIntentAddress(
-            maliciousIntent
-        );
 
         // Funds arrive from the bridge onto the destination chain victim's
         // intent address

--- a/packages/contract/test/DaimoPay.t.sol
+++ b/packages/contract/test/DaimoPay.t.sol
@@ -10,22 +10,22 @@ import "../src/DaimoPayCCTPBridger.sol";
 import "../src/DaimoPayCCTPV2Bridger.sol";
 import "../src/DaimoPayAcrossBridger.sol";
 import "../src/DaimoPayAxelarBridger.sol";
+import "./dummy/DummyFinalCallContract.sol";
 import "./dummy/DummyUSDC.sol";
 import "./dummy/across.sol";
 import "./dummy/axelar.sol";
 import "./dummy/cctp.sol";
 import "./dummy/cctpv2.sol";
 
-address constant CCTP_INTENT_ADDR = 0x5a1CE7235BeDd4B3Da3046B00d667829F3c493bB;
-address constant CCTP_V2_INTENT_ADDR = 0x4F6Ec5745b44877ACdF1192A6aFc57Ef66CeD23b;
-address constant ACROSS_INTENT_ADDR = 0xDE181e1Bac63C9EFA9E5fAa3Dfd60a209D57a099;
-address constant AXELAR_INTENT_ADDR = 0xFa0EdaAcCedB5e4BEBF89b8cdAE385FF498904c9;
+address constant CCTP_INTENT_ADDR = 0xF3490B45EC3676B24C7e939A0e73eD126336c1Aa;
+address constant CCTP_V2_INTENT_ADDR = 0x5a31C566EAeF59a622d5B97112879531df598E6d;
+address constant ACROSS_INTENT_ADDR = 0x20670e02a2c586aD5e92401dFE5E16C0EBFD1771;
+address constant AXELAR_INTENT_ADDR = 0x35D627518Ff40170026977AEcc939b5864Dd03E0;
 
 contract DaimoPayTest is Test {
     // Daimo Pay contracts
     DaimoPay public dp;
     PayIntentFactory public intentFactory;
-    DaimoPayExecutioner public executioner;
 
     // Bridging contracts
     DaimoPayBridger public bridger;
@@ -223,13 +223,11 @@ contract DaimoPayTest is Test {
         });
 
         intentFactory = new PayIntentFactory();
-        executioner = new DaimoPayExecutioner();
-        dp = new DaimoPay(intentFactory, executioner);
-        executioner.initialize(payable(address(dp)));
+        dp = new DaimoPay(intentFactory);
 
         // Log addresses of initialized contracts
         console.log("PayIntentFactory address:", address(intentFactory));
-        console.log("DaimoPayExecutioner address:", address(executioner));
+        console.log("DaimoPayExecutor address:", address(dp.executor()));
         console.log("DummyTokenMinter address:", address(tokenMinter));
         console.log("DummyCCTPMessenger address:", address(messenger));
         console.log("DummyTokenMinterV2 address:", address(tokenMinterV2));
@@ -674,6 +672,10 @@ contract DaimoPayTest is Test {
         // The Across bridger should only take what is needed to cover the fee.
         uint256 expectedInputAmount = 110; // _toAmount with 10 USDC flat fee
 
+        // Extra tokens should be refunded to the caller
+        vm.expectEmit(address(_fromToken));
+        emit IERC20.Transfer(address(dp.executor()), _alice, 10);
+
         vm.expectEmit(address(acrossBridger));
         emit IDaimoPayBridger.BridgeInitiated({
             fromAddress: address(bridger),
@@ -684,10 +686,6 @@ contract DaimoPayTest is Test {
             toToken: address(_toToken),
             toAmount: _toAmount
         });
-
-        // Extra tokens should be refunded to the caller
-        vm.expectEmit(address(_fromToken));
-        emit IERC20.Transfer(address(dp), _alice, 10);
 
         vm.expectEmit(address(dp));
         emit DaimoPay.Start(ACROSS_INTENT_ADDR, intent);
@@ -900,7 +898,7 @@ contract DaimoPayTest is Test {
 
         // An extra 9 of finalCallToken should be sent back to the LP
         vm.expectEmit(address(_toToken));
-        emit IERC20.Transfer(address(dp), _lp, 9);
+        emit IERC20.Transfer(address(dp.executor()), _lp, 9);
 
         dp.fastFinishIntent({
             intent: intent,
@@ -1174,6 +1172,97 @@ contract DaimoPayTest is Test {
         assertEq(actualSmallInputToken, address(_fromToken), "incorrect token");
     }
 
+    // Test that the DaimoPayExecutor contract functions are only callable by
+    // the escrow contract
+    function testExecutorOnlyCallableByEscrow() public {
+        DaimoPayExecutor executor = DaimoPayExecutor(
+            payable(address(dp.executor()))
+        );
+
+        // Try calling execute as Alice
+        vm.startPrank(_alice);
+        vm.expectRevert(bytes("DPCE: only escrow"));
+        executor.execute({
+            calls: new Call[](0),
+            expectedOutput: new TokenAmount[](0),
+            recipient: payable(_alice),
+            surplusRecipient: payable(_alice)
+        });
+        vm.stopPrank();
+
+        // Try calling executeFinalCall as Alice
+        vm.startPrank(_alice);
+        vm.expectRevert(bytes("DPCE: only escrow"));
+        executor.executeFinalCall({
+            finalCall: Call({to: _bob, value: 0, data: ""}),
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount})
+        });
+        vm.stopPrank();
+    }
+
+    function testExecutorRefundsSurplusTokens() public {
+        DaimoPayExecutor executor = DaimoPayExecutor(
+            payable(address(dp.executor()))
+        );
+
+        // Give executor 10 extra tokens
+        _toToken.transfer(address(executor), _toAmount + 10);
+
+        TokenAmount[] memory expectedOutput = new TokenAmount[](1);
+        expectedOutput[0] = TokenAmount({token: _toToken, amount: _toAmount});
+
+        // Call execute as the escrow contract
+        vm.startPrank(address(dp));
+        executor.execute({
+            calls: new Call[](0),
+            expectedOutput: expectedOutput,
+            recipient: payable(address(dp)),
+            surplusRecipient: payable(_alice)
+        });
+        vm.stopPrank();
+
+        // The executor should have the expected token output
+        assertEq(_toToken.balanceOf(address(dp)), _toAmount);
+
+        // Alice should have the extra 10 tokens
+        assertEq(_toToken.balanceOf(_alice), 10);
+    }
+
+    function testExecutorFinalCall() public {
+        DaimoPayExecutor executor = DaimoPayExecutor(
+            payable(address(dp.executor()))
+        );
+
+        // Deploy the dummy final call contract
+        DummyFinalCallContract dummyFinalCallContract = new DummyFinalCallContract();
+
+        // Give executor tokens
+        _toToken.transfer(address(executor), _toAmount);
+
+        // Setup the finalCall to call the dummy final call contract
+        Call memory finalCall = Call({
+            to: address(dummyFinalCallContract),
+            value: 0,
+            data: abi.encodeCall(
+                DummyFinalCallContract.transferFromToken,
+                (address(_toToken), address(executor), _bob, _toAmount)
+            )
+        });
+
+        // Call executeFinalCall as the escrow contract. The executor should
+        // approve finalCall.to before executing the call, so the transferFrom
+        // should succeed.
+        vm.startPrank(address(dp));
+        executor.executeFinalCall({
+            finalCall: finalCall,
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount})
+        });
+        vm.stopPrank();
+
+        // Bob should have the tokens
+        assertEq(_toToken.balanceOf(_bob), _toAmount);
+    }
+
     // Assuming that Alice has already transferred to the intent address
     // Assuming that relayer has already called `startIntent` on the source chain
     // We are on the destination chain
@@ -1265,5 +1354,94 @@ contract DaimoPayTest is Test {
 
         console.log("intentBalance", _toToken.balanceOf(intentAddress));
         console.log("maliciousBalance", _toToken.balanceOf(maliciousRelayer));
+    }
+
+    // Tries to use the arbitrary calls within the DaimoPay contract to make a
+    // call to the `sendTokens` function on an intent. The goal of the call is
+    // to circumvent the normal validations done in the DaimoPay contract after
+    // `sendTokens` is called.
+    function testMaliciousIntentDrain() public {
+        vm.chainId(_acrossDestChainId);
+
+        PayIntent memory victimIntent = PayIntent({
+            toChainId: _acrossDestChainId,
+            bridgeTokenOutOptions: getBridgeTokenOutOptions(),
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount}),
+            finalCall: Call({to: _bob, value: 0, data: ""}),
+            bridger: IDaimoPayBridger(bridger),
+            escrow: payable(address(dp)),
+            refundAddress: _alice,
+            nonce: _nonce
+        });
+
+        PayIntent memory maliciousIntent = PayIntent({
+            toChainId: _acrossDestChainId,
+            bridgeTokenOutOptions: getBridgeTokenOutOptions(),
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount}),
+            finalCall: Call({to: _bob, value: 0, data: ""}),
+            bridger: IDaimoPayBridger(bridger),
+            escrow: payable(address(dp)),
+            refundAddress: _bob,
+            nonce: _nonce
+        });
+
+        address maliciousRelayer = address(
+            0x4444444444444444444444444444444444444444
+        );
+        address victimIntentAddress = intentFactory.getIntentAddress(
+            victimIntent
+        );
+        address maliciousIntentAddress = intentFactory.getIntentAddress(
+            maliciousIntent
+        );
+
+        // Funds arrive from the bridge onto the destination chain victim's
+        // intent address
+        _toToken.transfer(victimIntentAddress, _toAmount);
+
+        // Attacker constructs arbitrary calls which will be executed during
+        // fastFinishIntent on his own malicious intent (the intent itself isn't
+        // malicious, but the arbitrary calls associated with it are)
+        Call[] memory calls = new Call[](2);
+        // Calldata to deploy the victim intent address
+        calls[0] = Call(
+            address(intentFactory),
+            0,
+            abi.encodeCall(PayIntentFactory.createIntent, (victimIntent))
+        );
+        // Calldata to call `sendTokens` on the victim intent address, trying to
+        // move funds from the victim intent address to the attacker address
+        IERC20[] memory drainTokens = new IERC20[](1);
+        drainTokens[0] = _toToken;
+        calls[1] = Call(
+            victimIntentAddress,
+            0,
+            abi.encodeCall(
+                PayIntentContract.sendTokens,
+                (victimIntent, drainTokens, payable(maliciousRelayer))
+            )
+        );
+
+        uint256 victimBalBefore = _toToken.balanceOf(victimIntentAddress);
+        uint256 attackerBalBefore = _toToken.balanceOf(maliciousRelayer);
+
+        // Malicious relayer sends funds to the DaimoPay contract to be able to
+        // fastFinishIntent their own intent
+        _toToken.transfer(address(dp), _toAmount);
+        // Malicious relayer fast finishes their own intent, to be able to use
+        // the arbitrary call to drain victims intent
+        vm.startPrank(maliciousRelayer);
+        IERC20[] memory fastFinishTokens = new IERC20[](1);
+        fastFinishTokens[0] = _toToken;
+        // Should revert because the call to `sendTokens` is not coming from
+        // the escrow contract
+        vm.expectRevert(bytes("DPCE: call failed"));
+        dp.fastFinishIntent(maliciousIntent, calls, fastFinishTokens);
+        vm.stopPrank();
+
+        uint256 victimBalAfter = _toToken.balanceOf(victimIntentAddress);
+        uint256 attackerBalAfter = _toToken.balanceOf(maliciousRelayer);
+        assertEq(victimBalAfter, victimBalBefore);
+        assertEq(attackerBalAfter, attackerBalBefore);
     }
 }

--- a/packages/contract/test/DaimoPay.t.sol
+++ b/packages/contract/test/DaimoPay.t.sol
@@ -373,8 +373,11 @@ contract DaimoPayTest is Test {
         // Since we're already on dest chain, startIntent verifies that we have
         // enough of bridgeTokenOut (see bridgeTokenOutOptions) post swap.
         // Simplest case: no swap, initial payment was already in correct token.
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _toToken;
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -389,10 +392,13 @@ contract DaimoPayTest is Test {
         PayIntent memory intent = getSimpleSameChainPayIntent();
         address intentAddr = intentFactory.getIntentAddress(intent);
 
+        IERC20[] memory refundTokens = new IERC20[](1);
+        refundTokens[0] = _toToken;
+
         // Since we are on the dest chain already, we *cannot* refund after
         // startIntent.
         vm.expectRevert(bytes("DP: not claimed"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Fast-finish it, fronting some native token.
         (bool success, ) = payable(address(dp)).call{value: 100}("");
@@ -401,16 +407,12 @@ contract DaimoPayTest is Test {
 
         // We still can't refund.
         vm.expectRevert(bytes("DP: not claimed"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Claim the intent.
         require(_toToken.balanceOf(intentAddr) == 100);
         dp.claimIntent({intent: intent, calls: new Call[](0)});
         require(_toToken.balanceOf(intentAddr) == 0);
-
-        // Nothing to refund.
-        vm.expectRevert(bytes("PI: no funds to refund"));
-        dp.refundIntent({intent: intent, token: _toToken});
 
         // Double-pay the intent...
         vm.prank(_alice);
@@ -419,7 +421,7 @@ contract DaimoPayTest is Test {
         assertEq(_toToken.balanceOf(_alice), 355);
 
         // ...and refund.
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Check that the intent was refunded.
         assertEq(_toToken.balanceOf(intentAddr), 0);
@@ -473,9 +475,12 @@ contract DaimoPayTest is Test {
         vm.expectEmit(address(dp));
         emit DaimoPay.Start(CCTP_INTENT_ADDR, intent);
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -512,16 +517,15 @@ contract DaimoPayTest is Test {
         PayIntent memory intent = getSimpleCrossChainPayIntent();
         address intentAddr = intentFactory.getIntentAddress(intent);
 
+        IERC20[] memory refundTokens = new IERC20[](1);
+        refundTokens[0] = _fromToken;
+
         // The intent hasn't been started yet, so we can't refund.
         vm.expectRevert(bytes("DP: not started"));
-        dp.refundIntent({intent: intent, token: _toToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Start the intent.
         testSimpleCCTPStart();
-
-        // Nothing to refund.
-        vm.expectRevert(bytes("PI: no funds to refund"));
-        dp.refundIntent({intent: intent, token: _toToken});
 
         // Double-pay the intent...
         vm.chainId(_fromChainId);
@@ -531,7 +535,7 @@ contract DaimoPayTest is Test {
         assertEq(_fromToken.balanceOf(_alice), 355);
 
         // ...and refund.
-        dp.refundIntent({intent: intent, token: _fromToken});
+        dp.refundIntent({intent: intent, tokens: refundTokens});
 
         // Check that the intent was refunded.
         assertEq(_fromToken.balanceOf(intentAddr), 0);
@@ -581,9 +585,12 @@ contract DaimoPayTest is Test {
         DaimoPayCCTPV2Bridger.ExtraData memory extraData = DaimoPayCCTPV2Bridger
             .ExtraData({maxFee: 0, minFinalityThreshold: 2000});
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: abi.encode(extraData)
         });
@@ -671,14 +678,17 @@ contract DaimoPayTest is Test {
 
         // Extra tokens should be refunded to the caller
         vm.expectEmit(address(_fromToken));
-        emit IERC20.Transfer(ACROSS_INTENT_ADDR, _alice, 10);
+        emit IERC20.Transfer(address(dp), _alice, 10);
 
         vm.expectEmit(address(dp));
         emit DaimoPay.Start(ACROSS_INTENT_ADDR, intent);
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: abi.encode(extraData)
         });
@@ -759,9 +769,12 @@ contract DaimoPayTest is Test {
             })
         );
 
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _fromToken;
         uint256 gasBefore = gasleft();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: bridgeExtraData
         });
@@ -991,7 +1004,7 @@ contract DaimoPayTest is Test {
             nonce: _nonce
         });
 
-        vm.expectRevert("PI: insufficient token received");
+        vm.expectRevert("DP: insufficient token received");
 
         dp.claimIntent({intent: intent, calls: new Call[](0)});
 
@@ -1033,9 +1046,12 @@ contract DaimoPayTest is Test {
         _unregisteredToken.transfer(intentAddr, _toAmount);
 
         // Expect revert due to token mismatch
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _unregisteredToken;
         vm.expectRevert();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -1069,9 +1085,12 @@ contract DaimoPayTest is Test {
         _unregisteredToken.transfer(intentAddr, _toAmount);
 
         // Expect revert due to token mismatch
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _unregisteredToken;
         vm.expectRevert();
         dp.startIntent({
             intent: intent,
+            paymentTokens: paymentTokens,
             calls: new Call[](0),
             bridgeExtraData: ""
         });
@@ -1131,5 +1150,98 @@ contract DaimoPayTest is Test {
         );
         // The Linea bridge route uses (_fromToken, _toToken) as the bridge token
         assertEq(actualSmallInputToken, address(_fromToken), "incorrect token");
+    }
+
+    // Assuming that Alice has already transferred to the intent address
+    // Assuming that relayer has already called `startIntent` on the source chain
+    // We are on the destination chain
+    // Before tokens have been successfully transferred to the bridge
+    // Before the relayer has called `fastFinishIntent` on the destination chain
+    function testMaliciousStartIntentOnDest() public {
+        vm.chainId(_acrossDestChainId);
+
+        PayIntent memory intent = PayIntent({
+            toChainId: _acrossDestChainId,
+            bridgeTokenOutOptions: getBridgeTokenOutOptions(),
+            finalCallToken: TokenAmount({token: _toToken, amount: _toAmount}),
+            finalCall: Call({to: _bob, value: 0, data: ""}),
+            escrow: payable(address(dp)),
+            bridger: bridger,
+            refundAddress: _alice,
+            nonce: _nonce
+        });
+
+        address intentAddress = intentFactory.getIntentAddress(intent);
+
+        // Malicious relayer does these actions
+        address maliciousRelayer = address(
+            0x4444444444444444444444444444444444444444
+        );
+        _toToken.transfer(maliciousRelayer, _toAmount);
+        vm.startPrank(maliciousRelayer);
+
+        // Malicious relayer will call `startIntent` and make an infinite
+        // approval to himself
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call(
+            address(_toToken),
+            0,
+            abi.encodeCall(
+                IERC20.approve,
+                (maliciousRelayer, type(uint256).max)
+            )
+        );
+
+        // Attacker calls `startIntent` on the destination chain, provides funds
+        // so no revert
+        _toToken.transfer(address(intentAddress), _toAmount);
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _toToken;
+        dp.startIntent({
+            intent: intent,
+            paymentTokens: paymentTokens,
+            calls: calls,
+            bridgeExtraData: ""
+        });
+        // Attacker tries using the allowance from the arbitrary call to take
+        // their amount back out of the intent address immediately. This should
+        // revert because the approval is from the escrow contract, not the
+        // intent address.
+        uint256 intentBalance = _toToken.balanceOf(intentAddress);
+        vm.expectRevert();
+        _toToken.transferFrom(
+            intentAddress,
+            address(maliciousRelayer),
+            intentBalance
+        );
+        // Attacker tries taking funds from the escrow contract. The escrow
+        // contract has not tokens, so the relayer gets nothing.
+        uint256 escrowBalance = _toToken.balanceOf(address(dp));
+        assertEq(escrowBalance, 0);
+        _toToken.transferFrom(
+            address(dp),
+            address(maliciousRelayer),
+            escrowBalance
+        );
+        assertEq(_toToken.balanceOf(maliciousRelayer), 0);
+
+        console.log("intentBalance", _toToken.balanceOf(intentAddress));
+        console.log("maliciousBalance", _toToken.balanceOf(maliciousRelayer));
+
+        vm.stopPrank();
+
+        // Now the actual funds arrive from the cross-chain bridge
+        _toToken.transfer(intentAddress, _toAmount);
+
+        // Attacker comes in and tries to take funds before a fastFinishIntent
+        // can be called by genuine relayer
+        vm.startPrank(maliciousRelayer);
+        uint256 intentBalance2 = _toToken.balanceOf(intentAddress);
+        vm.expectRevert();
+        _toToken.transferFrom(intentAddress, maliciousRelayer, intentBalance2);
+        vm.stopPrank();
+
+        console.log("intentBalance", _toToken.balanceOf(intentAddress));
+        console.log("maliciousBalance", _toToken.balanceOf(maliciousRelayer));
     }
 }

--- a/packages/contract/test/DaimoPay.t.sol
+++ b/packages/contract/test/DaimoPay.t.sol
@@ -16,15 +16,16 @@ import "./dummy/axelar.sol";
 import "./dummy/cctp.sol";
 import "./dummy/cctpv2.sol";
 
-address constant CCTP_INTENT_ADDR = 0x99755A0F204e89fA3f1DdEB33e08E2b3cb845f08;
-address constant CCTP_V2_INTENT_ADDR = 0xECC9D95bb1e79F676E5f2B0408Eb2a0170dbfD81;
-address constant ACROSS_INTENT_ADDR = 0x00308C0494226f39e42BDe37695368D76236D934;
-address constant AXELAR_INTENT_ADDR = 0x11B0ae9eA3c56Bbaa025Cc24357d8Ba6B4552441;
+address constant CCTP_INTENT_ADDR = 0x5a1CE7235BeDd4B3Da3046B00d667829F3c493bB;
+address constant CCTP_V2_INTENT_ADDR = 0x4F6Ec5745b44877ACdF1192A6aFc57Ef66CeD23b;
+address constant ACROSS_INTENT_ADDR = 0xDE181e1Bac63C9EFA9E5fAa3Dfd60a209D57a099;
+address constant AXELAR_INTENT_ADDR = 0xFa0EdaAcCedB5e4BEBF89b8cdAE385FF498904c9;
 
 contract DaimoPayTest is Test {
     // Daimo Pay contracts
     DaimoPay public dp;
     PayIntentFactory public intentFactory;
+    DaimoPayExecutioner public executioner;
 
     // Bridging contracts
     DaimoPayBridger public bridger;
@@ -81,8 +82,6 @@ contract DaimoPayTest is Test {
     uint256 immutable _nonce = 1;
 
     function setUp() public {
-        intentFactory = new PayIntentFactory();
-
         // Initialize CCTP bridger
         tokenMinter = new DummyTokenMinter();
         tokenMinter.setLocalToken(
@@ -223,10 +222,14 @@ contract DaimoPayTest is Test {
             _bridgers: bridgers
         });
 
-        dp = new DaimoPay(intentFactory);
+        intentFactory = new PayIntentFactory();
+        executioner = new DaimoPayExecutioner();
+        dp = new DaimoPay(intentFactory, executioner);
+        executioner.initialize(payable(address(dp)));
 
         // Log addresses of initialized contracts
         console.log("PayIntentFactory address:", address(intentFactory));
+        console.log("DaimoPayExecutioner address:", address(executioner));
         console.log("DummyTokenMinter address:", address(tokenMinter));
         console.log("DummyCCTPMessenger address:", address(messenger));
         console.log("DummyTokenMinterV2 address:", address(tokenMinterV2));
@@ -403,7 +406,13 @@ contract DaimoPayTest is Test {
         // Fast-finish it, fronting some native token.
         (bool success, ) = payable(address(dp)).call{value: 100}("");
         require(success, "send failed");
-        dp.fastFinishIntent({intent: intent, calls: new Call[](0)});
+        IERC20[] memory fastFinishTokens = new IERC20[](1);
+        fastFinishTokens[0] = IERC20(address(0));
+        dp.fastFinishIntent({
+            intent: intent,
+            calls: new Call[](0),
+            tokens: fastFinishTokens
+        });
 
         // We still can't refund.
         vm.expectRevert(bytes("DP: not claimed"));
@@ -829,8 +838,11 @@ contract DaimoPayTest is Test {
             nonce: _nonce
         });
 
-        // LP transfers the token to the intent address
+        // LP transfers the token to the DaimoPay escrow contract to call
+        // fastFinishIntent.
         _toToken.transfer({to: address(dp), value: _toAmount});
+        IERC20[] memory fastFinishTokens = new IERC20[](1);
+        fastFinishTokens[0] = _toToken;
 
         vm.expectEmit(address(dp));
         emit DaimoPay.IntentFinished({
@@ -845,7 +857,11 @@ contract DaimoPayTest is Test {
             newRecipient: _lp
         });
 
-        dp.fastFinishIntent({intent: intent, calls: new Call[](0)});
+        dp.fastFinishIntent({
+            intent: intent,
+            calls: new Call[](0),
+            tokens: fastFinishTokens
+        });
 
         vm.stopPrank();
 
@@ -879,12 +895,18 @@ contract DaimoPayTest is Test {
         // LP transfers too much of finalCallToken to finish the intent.
         // Only 1 is needed, but 10 is sent.
         _toToken.transfer({to: address(dp), value: 10});
+        IERC20[] memory fastFinishTokens = new IERC20[](1);
+        fastFinishTokens[0] = _toToken;
 
         // An extra 9 of finalCallToken should be sent back to the LP
         vm.expectEmit(address(_toToken));
         emit IERC20.Transfer(address(dp), _lp, 9);
 
-        dp.fastFinishIntent({intent: intent, calls: new Call[](0)});
+        dp.fastFinishIntent({
+            intent: intent,
+            calls: new Call[](0),
+            tokens: fastFinishTokens
+        });
 
         vm.stopPrank();
 
@@ -1004,7 +1026,7 @@ contract DaimoPayTest is Test {
             nonce: _nonce
         });
 
-        vm.expectRevert("DP: insufficient token received");
+        vm.expectRevert("PI: insufficient balance");
 
         dp.claimIntent({intent: intent, calls: new Call[](0)});
 

--- a/packages/contract/test/Relayer.t.sol
+++ b/packages/contract/test/Relayer.t.sol
@@ -57,6 +57,9 @@ contract RelayerTest is Test {
     }
 
     function testOnlyRelayerRoleCanStartIntent() public {
+        IERC20[] memory paymentTokens = new IERC20[](1);
+        paymentTokens[0] = _token1;
+
         vm.startPrank(_noRole);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -69,6 +72,7 @@ contract RelayerTest is Test {
             preCalls: new Call[](0),
             dp: DaimoPay(payable(address(mockDp))),
             intent: createSampleIntent(),
+            paymentTokens: paymentTokens,
             startCalls: new Call[](0),
             bridgeExtraData: "",
             postCalls: new Call[](0)
@@ -80,6 +84,7 @@ contract RelayerTest is Test {
             preCalls: new Call[](0),
             dp: DaimoPay(payable(address(mockDp))),
             intent: createSampleIntent(),
+            paymentTokens: paymentTokens,
             startCalls: new Call[](0),
             bridgeExtraData: "",
             postCalls: new Call[](0)
@@ -575,6 +580,7 @@ contract MockDaimoPay {
 
     function startIntent(
         PayIntent calldata intent,
+        IERC20[] calldata paymentTokens,
         Call[] calldata calls,
         bytes calldata bridgeExtraData
     ) public {}

--- a/packages/contract/test/Relayer.t.sol
+++ b/packages/contract/test/Relayer.t.sol
@@ -587,7 +587,8 @@ contract MockDaimoPay {
 
     function fastFinishIntent(
         PayIntent calldata intent,
-        Call[] calldata calls
+        Call[] calldata calls,
+        IERC20[] calldata tokens
     ) public {}
 
     function claimIntent(

--- a/packages/contract/test/dummy/DummyFinalCallContract.sol
+++ b/packages/contract/test/dummy/DummyFinalCallContract.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.12;
+
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+contract DummyFinalCallContract {
+    function transferFromToken(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) external {
+        IERC20(token).transferFrom(from, to, amount);
+    }
+}


### PR DESCRIPTION
Fixes issues described in sections 6.1 and 6.2 of audit NM-0500 - Daimo Pay Smart Contracts

The fix is to create a dedicated `DaimoPayExecutor` contract to isolate arbitrary relayer calls. This contract will have no special permissions and not hold funds between txs.

Updated flow:
1. The relayer calls `startIntent`, `fastFinishIntent` or `claimIntent` on the `DaimoPay` escrow contract
2. The escrow contract instructs the intent contract to transfer tokens to the `DaimoPayExecutor`
3. `DaimoPayExecutor` executes the relayer's arbitrary calls and returns output tokens to the escrow
4. The escrow verifies it received the expected token amount as specified in the intent
5. If verification passes, the escrow completes the remaining logic, otherwise it reverts

This setup fixes both reported exploits by ensuring the arbitrary relayer calls:
- Cannot approve or transfer on behalf of the intent
- Cannot pull funds from intents, since it's not called from the escrow contract
- Cannot call escrow functions due to reentrancy guard