### PR TITLE
sdk: fix reset order

### DIFF
--- a/packages/connectkit/src/hooks/usePaymentState.ts
+++ b/packages/connectkit/src/hooks/usePaymentState.ts
@@ -451,9 +451,10 @@ export function usePaymentState({
     }
   };
 
-  const resetOrder = () => {
-    setDaimoPayOrder(undefined);
-  };
+  const resetOrder = useCallback(() => {
+    if (payParams == null) return;
+    generatePreviewOrder(payParams);
+  }, [payParams]);
 
   return {
     setPayId,


### PR DESCRIPTION
calling reset order currently causes unexpected behavior. e.g. the button to become unclickable