### PR TITLE
metamask deeplink fix

### DIFF
--- a/packages/connectkit/src/wallets/walletConfigs.tsx
+++ b/packages/connectkit/src/wallets/walletConfigs.tsx
@@ -199,8 +199,9 @@ export const walletConfigs: {
     },
     showInMobileConnectors: false,
     getWalletConnectDeeplink: (uri: string) => {
-      return `https://metamask.app.link/wc?uri=${encodeURIComponent(uri)}`;
+      return `metamask://wc?uri=${encodeURIComponent(uri)}`;
     },
+    walletDeepLink: "metamask://",
   },
   "app.phantom": {
     name: "Phantom",


### PR DESCRIPTION
Switched from https://metamask.app.link/ to metamask:// for WalletConnect deeplink to prevent blank page issues in webview page sheets.