### PR TITLE
paykit: expose resetPayment function

### DIFF
--- a/examples/nextjs-app/src/app/basic/page.tsx
+++ b/examples/nextjs-app/src/app/basic/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { DaimoPayButton } from "@daimo/pay";
+import { DaimoPayButton, useDaimoPayUI } from "@daimo/pay";
 import * as Tokens from "@daimo/pay-common";
 import {
   getChainName,
@@ -13,6 +13,13 @@ import CodeSnippet from "../code-snippet";
 import { ConfigPanel } from "../config-panel";
 import { APP_ID, Container, printEvent, usePersistedConfig } from "../shared";
 
+type Config = {
+  recipientAddress: string;
+  chainId: number;
+  tokenAddress: string;
+  amount: string;
+};
+
 export default function DemoBasic() {
   const [isConfigOpen, setIsConfigOpen] = useState(false);
   const [config, setConfig] = usePersistedConfig("daimo-basic-config", {
@@ -20,8 +27,19 @@ export default function DemoBasic() {
     chainId: 0,
     tokenAddress: "",
     amount: "",
-  });
+  } as Config);
   const [codeSnippet, setCodeSnippet] = useState("");
+  const { resetPayment } = useDaimoPayUI();
+
+  const handleSetConfig = (config: Config) => {
+    setConfig(config);
+    resetPayment({
+      toChain: config.chainId,
+      toAddress: getAddress(config.recipientAddress),
+      toUnits: config.amount,
+      toToken: getAddress(config.tokenAddress),
+    });
+  };
 
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {
@@ -141,7 +159,7 @@ export default function DemoBasic() {
           configType="payment"
           isOpen={isConfigOpen}
           onClose={() => setIsConfigOpen(false)}
-          onConfirm={setConfig}
+          onConfirm={handleSetConfig}
           defaultRecipientAddress={config.recipientAddress}
         />
       </div>

--- a/packages/connectkit/src/hooks/useDaimoPayUI.tsx
+++ b/packages/connectkit/src/hooks/useDaimoPayUI.tsx
@@ -1,0 +1,18 @@
+import { useContext } from "react";
+import { PayParams } from "../payment/paymentFsm";
+import { PayContext } from "../provider/PayContext";
+
+type UseDaimoPayUI = {
+  resetPayment: (payParams?: Partial<PayParams>) => Promise<void>;
+};
+
+export function useDaimoPayUI(): UseDaimoPayUI {
+  const context = useContext(PayContext);
+  if (!context) {
+    throw new Error("useDaimoPayUI must be used within a DaimoPayUIProvider");
+  }
+
+  return {
+    resetPayment: context.paymentState.resetOrder,
+  };
+}

--- a/packages/connectkit/src/hooks/useExtractWcWallet.tsx
+++ b/packages/connectkit/src/hooks/useExtractWcWallet.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Connector } from "wagmi";
+import { PayLogFn } from "../provider/PayContext";
 import { WalletConfigProps, walletConfigs } from "../wallets/walletConfigs";
-import { PayLogFn } from "./usePayContext";
 
 /** Extracts wcWallet from the current WalletConnect connector. */
 export function useExtractWcWallet({

--- a/packages/connectkit/src/hooks/usePayContext.ts
+++ b/packages/connectkit/src/hooks/usePayContext.ts
@@ -1,17 +1,5 @@
-import React, { createContext } from "react";
-import { SolanaWalletName } from "../provider/SolanaContextProvider";
-import { ROUTES } from "../constants/routes";
-import { Languages } from "../localizations";
-import {
-  CustomTheme,
-  DaimoPayContextOptions,
-  DaimoPayModalOptions,
-  Mode,
-  Theme,
-} from "../types";
-import { WalletConfigProps } from "../wallets/walletConfigs";
-import { useConnectCallbackProps } from "./useConnectCallback";
-import { PaymentState } from "./usePaymentState";
+import React from "react";
+import { PayContext } from "../provider/PayContext";
 
 /** Daimo Pay internal context. */
 export const usePayContext = () => {
@@ -19,66 +7,3 @@ export const usePayContext = () => {
   if (!context) throw Error("DaimoPay Hook must be inside a Provider.");
   return context;
 };
-
-/** Meant for internal use. This will be non-exported in a future SDK version. */
-export const PayContext = createContext<PayContextValue | null>(null);
-
-export type PayLogFn = (message: string, ...props: any[]) => void;
-
-/** Daimo Pay internal context. */
-export type PayContextValue = {
-  theme: Theme;
-  setTheme: React.Dispatch<React.SetStateAction<Theme>>;
-  mode: Mode;
-  setMode: React.Dispatch<React.SetStateAction<Mode>>;
-  customTheme: CustomTheme | undefined;
-  setCustomTheme: React.Dispatch<React.SetStateAction<CustomTheme | undefined>>;
-  lang: Languages;
-  setLang: React.Dispatch<React.SetStateAction<Languages>>;
-  setOnOpen: (fn?: () => void) => void;
-  setOnClose: (fn?: () => void) => void;
-  open: boolean;
-  setOpen: (open: boolean, meta?: Record<string, any>) => void;
-  route: string;
-  setRoute: (route: ROUTES, data?: Record<string, any>) => void;
-  errorMessage: string | React.ReactNode | null;
-  debugMode?: boolean;
-  log: PayLogFn;
-  displayError: (message: string | React.ReactNode | null, code?: any) => void;
-  resize: number;
-  triggerResize: () => void;
-
-  // All options below are new, specific to Daimo Pay.
-  /** Session ID. */
-  sessionId: string;
-  /** EVM mobile connector */
-  wcWallet: WalletConfigProps | undefined;
-  /** EVM pending connector */
-  pendingConnectorId: string | undefined;
-  setPendingConnectorId: (id: string) => void;
-  /** Chosen Solana wallet, eg Phantom.*/
-  solanaConnector: SolanaWalletName | undefined;
-  setSolanaConnector: React.Dispatch<
-    React.SetStateAction<SolanaWalletName | undefined>
-  >;
-  /** Global options, across all pay buttons and payments. */
-  options?: DaimoPayContextOptions;
-  /** Loads a payment, then shows the modal to complete payment. */
-  showPayment: (modalOptions: DaimoPayModalOptions) => Promise<void>;
-  /** Payment status & callbacks. */
-  paymentState: PaymentState;
-  /** TRPC API client. Internal use only. */
-  trpc: any;
-  /** Callback to call when the payment is successful. */
-  onSuccess: () => void;
-  /** Custom message to display on confirmation page. */
-  confirmationMessage?: string;
-  setConfirmationMessage: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
-  /** Redirect URL to return to the app. E.g. after Coinbase, Binance, RampNetwork. */
-  redirectReturnUrl?: string;
-  setRedirectReturnUrl: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
-} & useConnectCallbackProps;

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -17,6 +17,7 @@ export {
 // Hooks to track payment status + UI status.
 export { useDaimoPay } from "./hooks/useDaimoPay";
 export { useDaimoPayStatus } from "./hooks/useDaimoPayStatus";
+export { useDaimoPayUI } from "./hooks/useDaimoPayUI";
 
 // TODO: replace with useDaimoPay() more comprehensive status.
 // export { useModal as useDaimoPayModal } from "./hooks/useModal";
@@ -33,7 +34,5 @@ export * from "./utils/exports";
 export * from "./types";
 
 // TODO: expose this more selectively.
-export {
-  PayContext as DaimoPayContext,
-  usePayContext,
-} from "./hooks/usePayContext";
+export { usePayContext } from "./hooks/usePayContext";
+export { PayContext as DaimoPayContext } from "./provider/PayContext";

--- a/packages/connectkit/src/provider/DaimoPayProvider.tsx
+++ b/packages/connectkit/src/provider/DaimoPayProvider.tsx
@@ -21,7 +21,6 @@ import {
 } from "../hooks/useConnectCallback";
 import { useDaimoPay } from "../hooks/useDaimoPay";
 import { useExtractWcWallet } from "../hooks/useExtractWcWallet";
-import { PayContext, PayContextValue } from "../hooks/usePayContext";
 import { usePaymentState } from "../hooks/usePaymentState";
 import { PaymentContext, PaymentProvider } from "../provider/PaymentProvider";
 import defaultTheme from "../styles/defaultTheme";
@@ -35,6 +34,7 @@ import {
 } from "../types";
 import { createTrpcClient } from "../utils/trpc";
 import { setInWalletPaymentUrlFromApiUrl } from "../wallets/walletConfigs";
+import { PayContext, PayContextValue } from "./PayContext";
 import {
   SolanaContextProvider,
   SolanaWalletName,

--- a/packages/connectkit/src/provider/PayContext.tsx
+++ b/packages/connectkit/src/provider/PayContext.tsx
@@ -1,0 +1,78 @@
+import React, { createContext } from "react";
+
+import { ROUTES } from "../constants/routes";
+import { useConnectCallbackProps } from "../hooks/useConnectCallback";
+import { PaymentState } from "../hooks/usePaymentState";
+import {
+  CustomTheme,
+  DaimoPayContextOptions,
+  DaimoPayModalOptions,
+  Languages,
+  Mode,
+  Theme,
+} from "../types";
+import { WalletConfigProps } from "../wallets/walletConfigs";
+import { SolanaWalletName } from "./SolanaContextProvider";
+
+/** Meant for internal use. This will be non-exported in a future SDK version. */
+export const PayContext = createContext<PayContextValue | null>(null);
+
+export type PayLogFn = (message: string, ...props: any[]) => void;
+
+/** Daimo Pay internal context. */
+export type PayContextValue = {
+  theme: Theme;
+  setTheme: React.Dispatch<React.SetStateAction<Theme>>;
+  mode: Mode;
+  setMode: React.Dispatch<React.SetStateAction<Mode>>;
+  customTheme: CustomTheme | undefined;
+  setCustomTheme: React.Dispatch<React.SetStateAction<CustomTheme | undefined>>;
+  lang: Languages;
+  setLang: React.Dispatch<React.SetStateAction<Languages>>;
+  setOnOpen: (fn?: () => void) => void;
+  setOnClose: (fn?: () => void) => void;
+  open: boolean;
+  setOpen: (open: boolean, meta?: Record<string, any>) => void;
+  route: string;
+  setRoute: (route: ROUTES, data?: Record<string, any>) => void;
+  errorMessage: string | React.ReactNode | null;
+  debugMode?: boolean;
+  log: PayLogFn;
+  displayError: (message: string | React.ReactNode | null, code?: any) => void;
+  resize: number;
+  triggerResize: () => void;
+
+  // All options below are new, specific to Daimo Pay.
+  /** Session ID. */
+  sessionId: string;
+  /** EVM mobile connector */
+  wcWallet: WalletConfigProps | undefined;
+  /** EVM pending connector */
+  pendingConnectorId: string | undefined;
+  setPendingConnectorId: (id: string) => void;
+  /** Chosen Solana wallet, eg Phantom.*/
+  solanaConnector: SolanaWalletName | undefined;
+  setSolanaConnector: React.Dispatch<
+    React.SetStateAction<SolanaWalletName | undefined>
+  >;
+  /** Global options, across all pay buttons and payments. */
+  options?: DaimoPayContextOptions;
+  /** Loads a payment, then shows the modal to complete payment. */
+  showPayment: (modalOptions: DaimoPayModalOptions) => Promise<void>;
+  /** Payment status & callbacks. */
+  paymentState: PaymentState;
+  /** TRPC API client. Internal use only. */
+  trpc: any;
+  /** Callback to call when the payment is successful. */
+  onSuccess: () => void;
+  /** Custom message to display on confirmation page. */
+  confirmationMessage?: string;
+  setConfirmationMessage: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+  /** Redirect URL to return to the app. E.g. after Coinbase, Binance, RampNetwork. */
+  redirectReturnUrl?: string;
+  setRedirectReturnUrl: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+} & useConnectCallbackProps;


### PR DESCRIPTION
expose `resetPayment` function in `useDaimoPayUI` hook. the dev passes in any fields of PayParams they want to update:

for example in our demo app:
```
const handleSetConfig = (config: Config) => {
    setConfig(config);
    resetPayment({
      toChain: config.chainId,
      toAddress: getAddress(config.recipientAddress),
      toUnits: config.amount,
      toToken: getAddress(config.tokenAddress),
    });
  };
```

https://github.com/user-attachments/assets/7ffd15e4-f961-49fd-ab91-426c37ad2b9a

