### PR TITLE
pay: fix WorldPayButton build, allow tree shaking

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -9,8 +9,14 @@
   "main": "./src/index.ts",
   "type": "module",
   "exports": {
-    "import": "./build/index.js",
-    "types": "./build/index.d.ts"
+    ".": {
+      "import": "./build/src/index.js",
+      "types": "./build/index.d.ts"
+    },
+    "./world": {
+      "import": "./build/src/world.js",
+      "types": "./build/world.d.ts"
+    }
   },
   "types": "./build/index.d.ts",
   "engines": {

--- a/packages/connectkit/rollup.config.js
+++ b/packages/connectkit/rollup.config.js
@@ -1,13 +1,12 @@
 import json from "@rollup/plugin-json";
 import typescript from "@rollup/plugin-typescript";
-import dts from "rollup-plugin-dts";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 
 /** @type {import('rollup').RollupOptions[]} */
 export default [
-  // Build bundle: index.js
+  // Build a folder of files for better tree-shaking
   {
-    input: ["./src/index.ts"],
+    input: ["./src/index.ts", "./src/world.ts"],
     external: [
       "react",
       "react-dom",
@@ -29,18 +28,20 @@ export default [
     ],
     output: [
       {
-        file: "build/index.js",
+        dir: "build",
         format: "esm",
         sourcemap: true,
+        preserveModules: true,
       },
     ],
-    plugins: [peerDepsExternal(), json(), typescript()],
-  },
-  // Build types: index.d.ts
-  {
-    input: "./src/index.ts",
-    output: { file: "build/index.d.ts", format: "esm" },
-    external: ["../package.json"],
-    plugins: [dts()],
+    plugins: [
+      peerDepsExternal(),
+      json(),
+      typescript({
+        declaration: true,
+        declarationDir: "build",
+        rootDir: "src",
+      }),
+    ],
   },
 ];

--- a/packages/connectkit/src/components/DaimoPayButton/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayButton/index.tsx
@@ -158,7 +158,7 @@ export function DaimoPayButton(props: DaimoPayButtonProps): JSX.Element {
           $useMode={mode ?? context.mode}
           $customTheme={customTheme ?? context.customTheme}
         >
-          <ThemeContainer onClick={!props.disabled && show}>
+          <ThemeContainer onClick={props.disabled ? undefined : show}>
             <ThemedButton
               theme={theme ?? context.theme}
               mode={mode ?? context.mode}

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -19,9 +19,6 @@ export { useDaimoPay } from "./hooks/useDaimoPay";
 export { useDaimoPayStatus } from "./hooks/useDaimoPayStatus";
 export { useDaimoPayUI } from "./hooks/useDaimoPayUI";
 
-// TODO: replace with useDaimoPay() more comprehensive status.
-// export { useModal as useDaimoPayModal } from "./hooks/useModal";
-
 // For convenience, export components to show connected account.
 export { default as Avatar } from "./components/Common/Avatar";
 export { default as ChainIcon } from "./components/Common/Chain";
@@ -36,10 +33,3 @@ export * from "./types";
 // TODO: expose this more selectively.
 export { usePayContext } from "./hooks/usePayContext";
 export { PayContext as DaimoPayContext } from "./provider/PayContext";
-
-// World Mini App
-export {
-  WorldPayButton,
-  WorldPayButtonCustomProps,
-  WorldPayButtonProps,
-} from "./world-mini-app/WorldPayButton";

--- a/packages/connectkit/src/stateStore.ts
+++ b/packages/connectkit/src/stateStore.ts
@@ -10,7 +10,7 @@
  * @template S The type of the state.
  * @template E The type of the events.
  */
-interface Store<S, E> {
+export interface Store<S, E> {
   getState: () => S;
   dispatch: (e: E) => void;
   subscribe: (l: listener<S, E>) => () => void;

--- a/packages/connectkit/src/world-mini-app/WorldPayButton.tsx
+++ b/packages/connectkit/src/world-mini-app/WorldPayButton.tsx
@@ -12,15 +12,13 @@ import { ResetContainer } from "../styles";
 import { CustomTheme, Mode, Theme } from "../types";
 import { promptWorldcoinPayment } from "./promptWorldPayment";
 
+import { MiniKit } from "@worldcoin/minikit-js";
+
 export type WorldPayButtonPaymentProps = {
   /**
    * Your public app ID. Specify either (payId) or (appId + parameters).
    */
   appId: string;
-  /**
-   * Your World Mini App app ID.
-   */
-  worldAppId: string;
   /**
    * Destination chain ID.
    */
@@ -90,7 +88,9 @@ export function WorldPayButton(props: WorldPayButtonProps) {
           $useMode={mode ?? context.mode}
           $customTheme={customTheme ?? context.customTheme}
         >
-          <ThemeContainer onClick={!props.disabled && isMiniKitReady && show}>
+          <ThemeContainer
+            onClick={props.disabled || !isMiniKitReady ? undefined : show}
+          >
             <ThemedButton>
               <DaimoPayButtonInner />
             </ThemedButton>
@@ -107,20 +107,10 @@ function WorldPayButtonCustom(props: WorldPayButtonCustomProps) {
   const [isMiniKitReady, setIsMiniKitReady] = useState(false);
 
   useEffect(() => {
-    // Dynamically import @worldcoin/minikit-js to avoid bundling it for
-    // developers who don't use World Mini App features, as it's an optional
-    // peer dependency.
-    import(/* webpackIgnore: true */ "@worldcoin/minikit-js")
-      .then(({ MiniKit }) => {
-        if (MiniKit.isInstalled()) {
-          setIsMiniKitReady(true);
-        } else {
-          setIsMiniKitReady(false);
-        }
-      })
-      .catch(() => {
-        setIsMiniKitReady(false);
-      });
+    const result = MiniKit.install();
+    context.log("MiniKit.install()", result);
+    setIsMiniKitReady(result.success);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -168,5 +158,3 @@ function WorldPayButtonCustom(props: WorldPayButtonCustomProps) {
 }
 
 WorldPayButton.displayName = "WorldPayButton";
-
-WorldPayButton.Custom = WorldPayButtonCustom;

--- a/packages/connectkit/src/world-mini-app/promptWorldPayment.ts
+++ b/packages/connectkit/src/world-mini-app/promptWorldPayment.ts
@@ -5,11 +5,14 @@ import {
   worldchainUSDC,
   worldchainWLD,
 } from "@daimo/pay-common";
-import type {
-  MiniAppPaymentPayload,
-  PayCommandInput,
-} from "@worldcoin/minikit-js";
 import { getAddress } from "viem";
+
+import {
+  MiniAppPaymentPayload,
+  MiniKit,
+  PayCommandInput,
+  Tokens,
+} from "@worldcoin/minikit-js";
 
 /**
  * Open Worldcoin's payment drawer and prompt the user to pay a Daimo Pay order.
@@ -19,12 +22,6 @@ export async function promptWorldcoinPayment(
   trpc: any,
 ): Promise<{ paymentId: string; finalPayload: MiniAppPaymentPayload } | null> {
   try {
-    // Dynamically import @worldcoin/minikit-js to avoid bundling it for
-    // developers who don't use World Mini App features, as it's an optional
-    // peer dependency.
-    const { MiniKit, Tokens } = await import(
-      /* webpackIgnore: true */ "@worldcoin/minikit-js"
-    );
     if (!MiniKit.isInstalled()) {
       console.error(
         "[WORLD] MiniKit is not installed. Please install @worldcoin/minikit-js to use this feature.",
@@ -54,7 +51,7 @@ export async function promptWorldcoinPayment(
     );
 
     assert(wld != null, "WLD DP token not found");
-    assert(usdc != null, "USDCe DP token not found");
+    assert(usdc != null, "USDC DP token not found");
 
     const paymentId = crypto.randomUUID().replace(/-/g, "");
     const payload: PayCommandInput = {

--- a/packages/connectkit/src/world.ts
+++ b/packages/connectkit/src/world.ts
@@ -1,0 +1,5 @@
+export {
+  WorldPayButton,
+  WorldPayButtonCustomProps,
+  WorldPayButtonProps,
+} from "./world-mini-app/WorldPayButton";


### PR DESCRIPTION
## Non-World apps work again

When you import DaimoPayButton etc from `@daimo/pay`, the import graph does not include `@worldcoin/minikit-js`. This keeps MiniKit an optional peer dependency.

## World apps are simplified

No more `worldAppId` prop for `WorldPayButton`. Instead, you pass that to the `MiniKitProvider`.

Updated code for docs:

#### page.tsx

```tsx
"use client";

import { WorldPayButton } from "@daimo/pay/world";
import { useMemo } from "react";

export default function Home() {
  return (
    <main style={useMemo(() => ({ padding: 16 }), [])}>
      <WorldPayButton
        appId="pay-demo"
        toAddress="0xc60A0A0E8bBc32DAC2E03030989AD6BEe45A874D"
        toChain={8453}
        toToken="0x0000000000000000000000000000000000000000"
        toUnits="0.0001"
        intent="Pay from World"
      />
    </main>
  );
}
```

#### `providers.tsx`

```tsx
"use client";

import { DaimoPayProvider, getDefaultConfig } from "@daimo/pay";
import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
import { MiniKitProvider } from "@worldcoin/minikit-js/minikit-provider";
import React, { useMemo } from "react";
import { WagmiProvider, createConfig } from "wagmi";

const config = createConfig(
  getDefaultConfig({
    appName: "YOUR APP NAME HERE",
  })
);

const queryClient = new QueryClient();

export function Providers({ children }: { children: React.ReactNode }) {
  const appId= "YOUR_WORLD_APP_ID_HERE";
  const miniKitProps = useMemo(() => ({ appId }), []);
  return (
    <MiniKitProvider props={miniKitProps}>
      <WagmiProvider config={config}>
        <QueryClientProvider client={queryClient}>
          <DaimoPayProvider>{children}</DaimoPayProvider>
        </QueryClientProvider>
      </WagmiProvider>
    </MiniKitProvider>
  );
}
```