### PR TITLE
Add disableMobileInjector option and filter WalletConnect from the Injector

### DIFF
--- a/packages/connectkit/src/components/DaimoPayModal/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/index.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from "../../constants/routes";
 import { getAppName } from "../../defaultConfig";
 import { useChainIsSupported } from "../../hooks/useChainIsSupported";
 import { useDaimoPay } from "../../hooks/useDaimoPay";
+import useIsMobile from "../../hooks/useIsMobile";
 import { usePayContext } from "../../hooks/usePayContext";
 import { CustomTheme, Languages, Mode, Theme } from "../../types";
 import Modal from "../Common/Modal";
@@ -40,19 +41,28 @@ export const DaimoPayModal: React.FC<{
   theme: Theme;
   customTheme: CustomTheme;
   lang: Languages;
+  disableMobileInjector: boolean;
 }> = ({
   mode,
   theme,
   customTheme,
   lang,
+  disableMobileInjector,
 }: {
   mode: Mode;
   theme: Theme;
   customTheme: CustomTheme;
   lang: Languages;
+  disableMobileInjector: boolean;
 }) => {
   const context = usePayContext();
-  const { setMode, setTheme, setCustomTheme, setLang } = context;
+  const {
+    setMode,
+    setTheme,
+    setCustomTheme,
+    setLang,
+    setDisableMobileInjector,
+  } = context;
   const paymentState = context.paymentState;
   const {
     generatePreviewOrder,
@@ -192,6 +202,7 @@ export const DaimoPayModal: React.FC<{
     }
     context.setOpen(false, { event: "click-close" });
   }
+  const { isMobile } = useIsMobile();
 
   // If the user has a wallet already connected upon opening the modal, go
   // straight to the select token screen
@@ -202,7 +213,12 @@ export const DaimoPayModal: React.FC<{
     // Skip to token selection if exactly one wallet is connected. If both
     // wallets are connected, stay on the SELECT_METHOD screen to allow the
     // user to select which wallet to use
-    if (isEthConnected && !isSolanaConnected) {
+    // If mobile injector is disabled, don't show the connected wallets.
+    if (
+      isEthConnected &&
+      !isSolanaConnected &&
+      (!isMobile || !disableMobileInjector)
+    ) {
       paymentState.setTokenMode("evm");
       context.setRoute(ROUTES.SELECT_TOKEN, {
         event: "eth_connected_on_open",
@@ -213,7 +229,8 @@ export const DaimoPayModal: React.FC<{
     } else if (
       isSolanaConnected &&
       !isEthConnected &&
-      showSolanaPaymentMethod
+      showSolanaPaymentMethod &&
+      !disableMobileInjector
     ) {
       paymentState.setTokenMode("solana");
       context.setRoute(ROUTES.SELECT_TOKEN, {
@@ -258,6 +275,10 @@ export const DaimoPayModal: React.FC<{
   useEffect(() => setTheme(theme), [theme, setTheme]);
   useEffect(() => setCustomTheme(customTheme), [customTheme, setCustomTheme]);
   useEffect(() => setLang(lang), [lang, setLang]);
+  useEffect(
+    () => setDisableMobileInjector(disableMobileInjector),
+    [disableMobileInjector, setDisableMobileInjector],
+  );
 
   useEffect(() => {
     const appName = getAppName();

--- a/packages/connectkit/src/components/Pages/SelectMethod/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectMethod/index.tsx
@@ -37,7 +37,8 @@ export default function SelectMethod() {
     disconnect: disconnectSolana,
     publicKey,
   } = useWallet();
-  const { setRoute, paymentState, log } = usePayContext();
+  const { setRoute, paymentState, log, disableMobileInjector } =
+    usePayContext();
   const { disconnectAsync } = useDisconnect();
 
   const {
@@ -48,8 +49,14 @@ export default function SelectMethod() {
   } = paymentState;
 
   // Decide whether to show the connected eth account, solana account, or both.
-  const showConnectedEth = isEthConnected;
-  const showConnectedSolana = isSolanaConnected && showSolanaPaymentMethod;
+  // Desktop: Always show connected wallets when available
+  // Mobile: Only show connected wallets when mobile injector is enabled (!disableMobileInjector)
+  const showConnectedEth =
+    isEthConnected && (!isMobile || !disableMobileInjector);
+  const showConnectedSolana =
+    isSolanaConnected &&
+    showSolanaPaymentMethod &&
+    (!isMobile || !disableMobileInjector);
 
   const getConnectedWalletOptions = () => {
     const showChainLogo = isEthConnected && isSolanaConnected;
@@ -258,6 +265,7 @@ function getBestUnconnectedWalletIcons(
   } else {
     if (!isRainbow) icons.push(<Rainbow />);
     if (!isPhantom) icons.push(<Phantom />);
+    if (!isCoinbase) icons.push(<Coinbase />);
   }
 
   return icons;

--- a/packages/connectkit/src/provider/DaimoPayProvider.tsx
+++ b/packages/connectkit/src/provider/DaimoPayProvider.tsx
@@ -119,6 +119,7 @@ const DaimoPayUIProvider = ({
     ethereumOnboardingUrl: undefined,
     walletOnboardingUrl: undefined,
     overlayBlur: undefined,
+    disableMobileInjector: false,
   };
 
   const opts: DaimoPayContextOptions = Object.assign(
@@ -147,6 +148,9 @@ const DaimoPayUIProvider = ({
     customTheme ?? {},
   );
   const [ckLang, setLang] = useState<Languages>("en-US");
+  const [disableMobileInjector, setDisableMobileInjector] = useState<boolean>(
+    opts.disableMobileInjector ?? false,
+  );
 
   const onOpenRef = useRef<(() => void) | undefined>();
   const onCloseRef = useRef<(() => void) | undefined>();
@@ -250,6 +254,10 @@ const DaimoPayUIProvider = ({
   // Other Configuration
   useEffect(() => setTheme(theme), [theme]);
   useEffect(() => setLang(opts.language || "en-US"), [opts.language]);
+  useEffect(
+    () => setDisableMobileInjector(opts.disableMobileInjector ?? false),
+    [opts.disableMobileInjector],
+  );
   useEffect(() => setErrorMessage(null), [route, open]);
 
   const paymentState = usePaymentState({
@@ -312,6 +320,8 @@ const DaimoPayUIProvider = ({
     setCustomTheme,
     lang: ckLang,
     setLang,
+    disableMobileInjector,
+    setDisableMobileInjector,
     setOnOpen,
     setOnClose,
     open,
@@ -363,6 +373,7 @@ const DaimoPayUIProvider = ({
           theme={ckTheme}
           mode={mode}
           customTheme={ckCustomTheme}
+          disableMobileInjector={disableMobileInjector}
         />
       </ThemeProvider>
     </Web3ContextProvider>,

--- a/packages/connectkit/src/provider/PayContext.tsx
+++ b/packages/connectkit/src/provider/PayContext.tsx
@@ -28,6 +28,8 @@ export type PayContextValue = {
   setCustomTheme: React.Dispatch<React.SetStateAction<CustomTheme | undefined>>;
   lang: Languages;
   setLang: React.Dispatch<React.SetStateAction<Languages>>;
+  disableMobileInjector: boolean;
+  setDisableMobileInjector: React.Dispatch<React.SetStateAction<boolean>>;
   setOnOpen: (fn?: () => void) => void;
   setOnClose: (fn?: () => void) => void;
   open: boolean;

--- a/packages/connectkit/src/types.ts
+++ b/packages/connectkit/src/types.ts
@@ -47,6 +47,8 @@ export type DaimoPayContextOptions = {
   walletOnboardingUrl?: string;
   /** Blur the background when the modal is open */
   overlayBlur?: number;
+  /** Disable mobile wallet injector detection */
+  disableMobileInjector?: boolean;
 };
 
 /** Modal UI options, set on the pay button triggering that modal. */


### PR DESCRIPTION
• Add an optional boolean disableMobileInjector to DaimoPayProvider.options.
• When true, the injected EIP 1193 connector (MetaMask in-app, Coinbase Wallet web-view, etc.) is hidden in mobile flows.
• Default is false, so existing integrations are unaffected.

2. WalletConnect filtered from the injected group
• WalletConnect no longer appears under the injected connector

3. Coinbase Wallet (CBW) icon on desktop
• The desktop Connect Wallet payment method now displays the CBW icon alongside the other first-party wallets.