### PR TITLE
fixed back button uniquePaymentMethod

### DIFF
--- a/packages/connectkit/src/components/Common/OrderHeader/index.tsx
+++ b/packages/connectkit/src/components/Common/OrderHeader/index.tsx
@@ -23,10 +23,10 @@ import { formatUsd } from "../../../utils/format";
 /** Shows payment amount. */
 export const OrderHeader = ({
   minified = false,
-  show = "all",
+  show = "showCoin",
 }: {
   minified?: boolean;
-  show?: "evm" | "solana" | "zkp2p" | "all";
+  show?: "evm" | "solana" | "hideCoin" | "showCoin";
 }) => {
   const { paymentState, route } = usePayContext();
   const { isConnected: isEthConnected, address, connector } = useAccount();
@@ -93,14 +93,6 @@ export const OrderHeader = ({
 
   if (minified) {
     if (titleAmountContent != null) {
-      if (show === "zkp2p") {
-        return (
-          <MinifiedContainer>
-            <MinifiedTitleAmount>{titleAmountContent}</MinifiedTitleAmount>
-          </MinifiedContainer>
-        );
-      }
-
       return (
         <MinifiedContainer>
           <MinifiedTitleAmount>{titleAmountContent}</MinifiedTitleAmount>
@@ -120,7 +112,7 @@ export const OrderHeader = ({
               </SubtitleContainer>
             </>
           )}
-          {show === "all" && (
+          {show === "showCoin" && (
             <>
               <CoinLogos $size={32} />
             </>
@@ -128,12 +120,14 @@ export const OrderHeader = ({
         </MinifiedContainer>
       );
     } else {
-      return (
-        <MinifiedContainer>
-          <CoinLogos />
-          <Subtitle>{locales.tokensAccepted}</Subtitle>
-        </MinifiedContainer>
-      );
+      if (show !== "hideCoin") {
+        return (
+          <MinifiedContainer>
+            <CoinLogos />
+            <Subtitle>{locales.tokensAccepted}</Subtitle>
+          </MinifiedContainer>
+        );
+      }
     }
   } else {
     return (

--- a/packages/connectkit/src/components/DaimoPayModal/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/index.tsx
@@ -119,7 +119,7 @@ export const DaimoPayModal: React.FC<{
       context.setRoute(ROUTES.SELECT_TOKEN, meta);
     } else if (context.route === ROUTES.SELECT_EXTERNAL_AMOUNT) {
       setSelectedExternalOption(undefined);
-      context.setRoute(ROUTES.SELECT_METHOD, meta);
+      context.setRoute(context.uniquePaymentMethodPage, meta);
     } else if (context.route === ROUTES.SELECT_DEPOSIT_ADDRESS_AMOUNT) {
       setSelectedDepositAddressOption(undefined);
       context.setRoute(ROUTES.SELECT_DEPOSIT_ADDRESS_CHAIN, meta);

--- a/packages/connectkit/src/components/Pages/SelectDepositAddressChain/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectDepositAddressChain/index.tsx
@@ -26,7 +26,7 @@ const SelectDepositAddressChain: React.FC = () => {
 
   return (
     <PageContent>
-      <OrderHeader minified />
+      <OrderHeader minified show="hideCoin" />
 
       {!depositAddressOptions.loading &&
         depositAddressOptions.options?.length === 0 && (

--- a/packages/connectkit/src/components/Pages/SelectExchange/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectExchange/index.tsx
@@ -15,7 +15,7 @@ const SelectExchange: React.FC = () => {
   if (!exchangeOptions) {
     return (
       <PageContent>
-        <OrderHeader minified show="zkp2p" />
+        <OrderHeader minified show="hideCoin" />
         <ModalH1>No Exchange options available</ModalH1>
       </PageContent>
     );
@@ -40,7 +40,7 @@ const SelectExchange: React.FC = () => {
 
   return (
     <PageContent>
-      <OrderHeader minified show="zkp2p" />
+      <OrderHeader minified show="hideCoin" />
       <OptionsList options={options} />
     </PageContent>
   );

--- a/packages/connectkit/src/components/Pages/SelectToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectToken/index.tsx
@@ -27,7 +27,7 @@ export default function SelectToken() {
   const isConnected = isEvmConnected || isSolConnected;
 
   const isAnotherMethodButtonVisible =
-    optionsList.length > 0 && tokenMode !== "all";
+    optionsList.length > 0 && tokenMode !== "showCoin";
 
   return (
     <PageContent>
@@ -45,7 +45,9 @@ export default function SelectToken() {
       {!isLoading && isConnected && optionsList.length === 0 && (
         <InsufficientBalance />
       )}
-      {!isLoading && !isConnected && tokenMode === "all" && <ConnectButton />}
+      {!isLoading && !isConnected && tokenMode === "showCoin" && (
+        <ConnectButton />
+      )}
       {isAnotherMethodButtonVisible && <SelectAnotherMethodButton />}
     </PageContent>
   );

--- a/packages/connectkit/src/components/Pages/SelectZKP/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectZKP/index.tsx
@@ -15,7 +15,7 @@ const SelectZKP: React.FC = () => {
   if (!zkp2pOptions) {
     return (
       <PageContent>
-        <OrderHeader minified show="zkp2p" />
+        <OrderHeader minified show="hideCoin" />
         <ModalH1>No ZKP2P options available</ModalH1>
       </PageContent>
     );
@@ -40,7 +40,7 @@ const SelectZKP: React.FC = () => {
 
   return (
     <PageContent>
-      <OrderHeader minified show="zkp2p" />
+      <OrderHeader minified show="hideCoin" />
       <OptionsList options={options} />
     </PageContent>
   );

--- a/packages/connectkit/src/hooks/usePaymentState.ts
+++ b/packages/connectkit/src/hooks/usePaymentState.ts
@@ -89,8 +89,8 @@ export interface PaymentState {
   selectedDepositAddressOption: DepositAddressPaymentOptionMetadata | undefined;
   getOrderUsdLimit: () => number;
   setPaymentWaitingMessage: (message: string | undefined) => void;
-  tokenMode: "evm" | "solana" | "all";
-  setTokenMode: (mode: "evm" | "solana" | "all") => void;
+  tokenMode: "evm" | "solana" | "showCoin";
+  setTokenMode: (mode: "evm" | "solana" | "showCoin") => void;
   setSelectedWallet: (wallet: WalletConfigProps | undefined) => void;
   setSelectedWalletDeepLink: (deepLink: string | undefined) => void;
   setSelectedExternalOption: (

--- a/packages/connectkit/src/hooks/useTokenOptions.tsx
+++ b/packages/connectkit/src/hooks/useTokenOptions.tsx
@@ -16,7 +16,7 @@ import useLocales from "./useLocales";
 import { usePayContext } from "./usePayContext";
 
 /// and Solana tokens. See OptionsList.
-export function useTokenOptions(mode: "evm" | "solana" | "all"): {
+export function useTokenOptions(mode: "evm" | "solana" | "showCoin"): {
   optionsList: Option[];
   isLoading: boolean;
 } {
@@ -44,7 +44,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "all"): {
 
   let optionsList: Option[] = [];
   let isLoading = false;
-  if (["evm", "all"].includes(mode)) {
+  if (["evm", "showCoin"].includes(mode)) {
     optionsList.push(
       ...getEvmTokenOptions(
         walletPaymentOptions.options ?? [],
@@ -57,7 +57,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "all"): {
     );
     isLoading ||= walletPaymentOptions.isLoading;
   }
-  if (["solana", "all"].includes(mode)) {
+  if (["solana", "showCoin"].includes(mode)) {
     optionsList.push(
       ...getSolanaTokenOptions(
         solanaPaymentOptions.options ?? [],


### PR DESCRIPTION
<img width="494" height="444" alt="Screenshot 2025-08-26 at 1 09 34 PM" src="https://github.com/user-attachments/assets/55d3ea1d-590e-4925-89c6-4adac90a3e54" />
<img width="444" height="268" alt="Screenshot 2025-08-26 at 1 09 30 PM" src="https://github.com/user-attachments/assets/c00fe1a8-2016-4f3d-b6c5-3a078aad7eb9" />

Removed the Coin header for Exchange and Pay to Address.
The back button for uniquePaymentMethod in Deposit mode now returns to the correct page.