### PR TITLE
fix: handle preview state in openInWalletBrowser for mobile deeplinks

### DIFF
--- a/packages/connectkit/src/components/Common/ConnectorList/index.tsx
+++ b/packages/connectkit/src/components/Common/ConnectorList/index.tsx
@@ -102,7 +102,7 @@ const ConnectorItem = ({
     (isBaseAccountConnector(wallet.connector?.id) ||
       isGeminiConnector(wallet.connector?.id));
 
-  const onClick = () => {
+  const onClick = async () => {
     const meta = { event: "connector-list-click", walletId: wallet.id };
 
     // Desktop multi-chain wallet flow: prompt for chain selection.
@@ -148,7 +148,7 @@ const ConnectorItem = ({
       wallet.getDaimoPayDeeplink != null &&
       !wallet.connector
     ) {
-      context.paymentState.openInWalletBrowser(wallet);
+      await context.paymentState.openInWalletBrowser(wallet);
     } else {
       if (shouldConnectImmediately) {
         connect({ connector: wallet.connector! });

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -30,7 +30,7 @@ const MobileConnectors: React.FC = () => {
       return true;
     }) ?? [];
 
-  const goToWallet = (wallet: WalletConfigProps) => {
+  const goToWallet = async (wallet: WalletConfigProps) => {
     if (wallet.getDaimoPayDeeplink == null) {
       console.error(`wallet ${wallet.name} has no deeplink`);
       return;
@@ -39,7 +39,7 @@ const MobileConnectors: React.FC = () => {
       context.paymentState.setSelectedWallet(wallet);
       setRoute(ROUTES.SELECT_WALLET_AMOUNT);
     } else {
-      paymentState.openInWalletBrowser(wallet);
+      await paymentState.openInWalletBrowser(wallet);
     }
   };
 

--- a/packages/connectkit/src/components/Pages/SelectWalletAmount/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectWalletAmount/index.tsx
@@ -40,15 +40,15 @@ const SelectWalletAmount: React.FC = () => {
   const handleContinue = async () => {
     const amountUsd = Number(sanitizeNumber(usdInput));
     setChosenUsd(amountUsd);
-    await hydrateOrder();
     if (
       selectedWallet.id === WALLET_ID_MOBILE_WALLETS ||
       (selectedWallet.id === "world" && !isMobile)
     ) {
+      await hydrateOrder();
       setPendingConnectorId(selectedWallet.id);
       setRoute(ROUTES.CONNECT);
     } else {
-      openInWalletBrowser(selectedWallet, amountUsd);
+      await openInWalletBrowser(selectedWallet, amountUsd);
     }
   };
 


### PR DESCRIPTION
Fixes assertion error when opening mobile wallets via deeplink from deposit flow.

### Problem
When users selected a mobile wallet with deeplink in the deposit flow, the app would crash with:
```
Assertion failed: "[OPEN IN WALLET BROWSER] paymentState is preview, must be payment_unpaid"
```
<img width="1294" height="332" alt="Screenshot 2025-10-14 at 5 15 45 PM" src="https://github.com/user-attachments/assets/23a10d96-b676-4ba1-a938-661da1e142c7" />

### Root Cause
`openInWalletBrowser` only accepted orders in `payment_unpaid` state, but callers (like `SelectWalletAmount`) would call it while the order was still in `preview` state after `setChosenUsd`.

### Solution
Made `openInWalletBrowser` follow the same pattern as `payWithToken`:
- Accept `preview`, `unhydrated`, or `payment_unpaid` states
- Hydrate order internally if not already hydrated
- Made function async to properly await hydration

### Changes
- Updated `usePaymentState.ts`: made `openInWalletBrowser` async and added internal hydration
- Updated all call sites to properly await: `SelectWalletAmount`, `MobileConnectors`, `ConnectorList`

### Testing
- ✅ Build passes
- ✅ Lint passes
- ✅ No new TypeScript errors