### PR TITLE
Fix connection to Metamask on desktop with extension

### DIFF
--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -355,10 +355,14 @@ const Modal: React.FC<ModalProps> = ({
     "--width": dimensions.width,
   } as React.CSSProperties;
 
-  // Show "Scan with phone" title for wallets with deeplinks (unique payment options)
+  // Show "Scan with phone" title only when we expect to show a QR/deeplink flow.
+  // Some wallets (e.g. MetaMask) support both injected connectors and deeplinks;
+  // if the extension is installed we should show the wallet name, not "Scan with phone".
   const hasDeeplink = wallet && wallet.getDaimoPayDeeplink;
+  const hasConnector = wallet && "connector" in wallet && wallet.connector != null;
+  const isInstalled = wallet && "isInstalled" in wallet && wallet.isInstalled;
   const shouldShowWalletQRCodeOnDesktop =
-    isExternalWallet(wallet) || hasDeeplink;
+    isExternalWallet(wallet) || (hasDeeplink && hasConnector && !isInstalled);
 
   function getHeading() {
     const payWithString = flattenChildren(locales.payWith).join("");


### PR DESCRIPTION
Bug: On desktop, selecting “Pay with wallet” in the modal would show a MetaMask option (when the MetaMask extension was installed). Clicking MetaMask prompted the user to choose “Ethereum” or “Solana”. If the user selected “Ethereum”, the app incorrectly displayed “Unsupported browser” despite the extension being installed.

Fix: This PR corrects the Ethereum + MetaMask desktop flow so users with the MetaMask extension no longer see the erroneous “Unsupported browser” message.