### PR TITLE
 fix: remove MetaMask exclusion from isInstalled check

### DIFF
--- a/packages/connectkit/src/wallets/useWallets.tsx
+++ b/packages/connectkit/src/wallets/useWallets.tsx
@@ -276,7 +276,7 @@ export const useWallets = (isMobile?: boolean): WalletProps[] => {
       iconShape: connector.id === RABBY_CONNECTOR_ID ? "circle" : "squircle",
       isInstalled:
         connector.type === "mock" ||
-        (connector.type === "injected" && connector.id !== "metaMask") ||
+        connector.type === "injected" ||
         connector.type === "farcasterFrame" ||
         isBaseAccountConnector(connector.id) ||
         isGeminiConnector(connector.id),


### PR DESCRIPTION
## Summary

- Fixes MetaMask showing as "unavailable" on desktop when the extension is installed
- Simplified fix based on the issue identified in #175

## Problem
The `isInstalled` check in `useWallets.tsx` explicitly excluded MetaMask:
```(connector.type === "injected" && connector.id !== "metaMask")```

This caused MetaMask to be marked `isInstalled: false` even when installed, triggering the` UNAVAILABLE` state in `ConnectWithInjector`.

## Solution
Remove the MetaMask exclusion - all injected connectors should be treated consistently:
```connector.type === "injected"```

## Credits
Thanks to @markusbug for identifying this issue in #175.