### PR TITLE
sdk: bundle Tailwind utilities at build time

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,7 @@
       "import": "./dist/web/api/index.js",
       "types": "./dist/web/api/index.d.ts"
     },
+    "./web/styles.css": "./dist/web/styles.css",
     "./web/theme.css": "./dist/web/theme.css"
   },
   "files": [
@@ -30,7 +31,7 @@
   ],
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput",
-    "build": "tsc && cp src/web/theme.css dist/web/theme.css",
+    "build": "tsc && cp src/web/theme.css dist/web/theme.css && npx tailwindcss -i src/web/styles.css -o dist/web/styles.css --minify",
     "test": "npm run lint",
     "lint": "eslint --max-warnings=0"
   },
@@ -60,6 +61,7 @@
     "@types/qrcode": "^1.4.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "tailwindcss": "^3.4.12",
     "typescript": "5.9.2"
   }
 }

--- a/packages/sdk/src/web/styles.css
+++ b/packages/sdk/src/web/styles.css
@@ -1,0 +1,15 @@
+/**
+ * Daimo Modal Styles
+ *
+ * Single import for consumers:
+ *   import "@daimo/sdk/web/styles.css";
+ *
+ * Includes compiled Tailwind utilities + theme variables + animations.
+ * Override --daimo-* CSS variables to customize appearance.
+ */
+
+/* Theme variables (light + dark) and custom component styles */
+@import "./theme.css";
+
+/* Compiled Tailwind utilities used by SDK components */
+@tailwind utilities;

--- a/packages/sdk/tailwind.config.js
+++ b/packages/sdk/tailwind.config.js
@@ -1,0 +1,7 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/web/**/*.tsx"],
+  corePlugins: { preflight: false },
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- SDK components use Tailwind utility classes but only shipped `theme.css` (CSS variables) — consumers without Tailwind got completely unstyled modals
- Add Tailwind v3 as a build-time devDependency, compile all used utilities into `dist/web/styles.css`
- Consumers now just need one import: `import "@daimo/sdk/web/styles.css"` — no Tailwind install or config required

## Changes
- `tailwind.config.js` — scans `src/web/**/*.tsx`, preflight disabled (no base reset)
- `src/web/styles.css` — imports theme.css + `@tailwind utilities`
- `package.json` — adds `tailwindcss` devDep, updates build script, exports `./web/styles.css`

## Test plan
- [x] `npm run build` succeeds, `dist/web/styles.css` contains theme vars + utilities (~14KB)
- [x] Integration app with only `import "@daimo/sdk/web/styles.css"` renders styled modal
- [x] No `@source` directive or Tailwind config needed on consumer side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daimo-eth/pay/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
