### PR TITLE
sdk: show error state on balance fetch failure

### DIFF
--- a/packages/sdk/src/web/components/DaimoModal.tsx
+++ b/packages/sdk/src/web/components/DaimoModal.tsx
@@ -307,8 +307,10 @@ type RenderContext = {
     isConnecting: boolean;
     isLoadingBalances: boolean;
     connectError: string | null;
+    balanceError: string | null;
     connect: () => Promise<void>;
     retryConnect: () => Promise<void>;
+    retryBalances: () => void;
   };
   onWalletSelectToken: (token: WalletPaymentOption) => void;
   onWalletSending: (token: WalletPaymentOption, amountUsd: number) => void;
@@ -482,7 +484,7 @@ function renderWalletConnect(entry: NavEntry & { type: "wallet-connect" }, ctx: 
 }
 
 function renderWalletSelectToken(ctx: RenderContext): React.ReactNode {
-  return <SelectTokenPage options={ctx.walletFlow.balances} isLoading={ctx.walletFlow.isLoadingBalances} onSelect={ctx.onWalletSelectToken} onBack={ctx.onBack} />;
+  return <SelectTokenPage options={ctx.walletFlow.balances} isLoading={ctx.walletFlow.isLoadingBalances} error={ctx.walletFlow.balanceError} onRetry={ctx.walletFlow.retryBalances} onSelect={ctx.onWalletSelectToken} onBack={ctx.onBack} sessionId={ctx.session.sessionId} />;
 }
 
 function renderWalletSelectAmount(entry: NavEntry & { type: "wallet-select-amount" }, ctx: RenderContext): React.ReactNode {

--- a/packages/sdk/src/web/components/SelectTokenPage.tsx
+++ b/packages/sdk/src/web/components/SelectTokenPage.tsx
@@ -2,7 +2,15 @@ import type { DaimoPayToken, WalletPaymentOption } from "../api/walletTypes.js";
 import { getChainName } from "../../common/chain.js";
 
 import { t } from "../hooks/locale.js";
-import { PageHeader, ScrollContent, TokenIconWithChainBadge } from "./shared.js";
+import { PrimaryButton } from "./buttons.js";
+import {
+  CenteredContent,
+  ContactSupportButton,
+  ErrorMessage as SharedErrorMessage,
+  PageHeader,
+  ScrollContent,
+  TokenIconWithChainBadge,
+} from "./shared.js";
 
 type SelectTokenPageProps = {
   /** Token options, or null if not yet loaded */
@@ -11,8 +19,14 @@ type SelectTokenPageProps = {
   isLoading?: boolean;
   /** Number of skeleton rows to show while loading */
   skeletonCount?: number;
+  /** Error message when balance fetch fails */
+  error?: string | null;
+  /** Retry callback for error state */
+  onRetry?: (() => void) | undefined;
   onSelect: (option: WalletPaymentOption) => void;
   onBack?: (() => void) | null;
+  /** Session ID for contact support */
+  sessionId?: string;
 };
 
 /** Token selection page for wallet payment flow */
@@ -20,9 +34,33 @@ export function SelectTokenPage({
   options,
   isLoading = false,
   skeletonCount = 11,
+  error,
+  onRetry,
   onSelect,
   onBack,
+  sessionId,
 }: SelectTokenPageProps) {
+  // Show error state when balance fetch fails
+  if (error) {
+    return (
+      <div className="flex flex-col flex-1 min-h-0">
+        <PageHeader title={t.selectToken} onBack={onBack} />
+        <CenteredContent>
+          <SharedErrorMessage message={error} />
+          {onRetry && (
+            <PrimaryButton onClick={onRetry}>{t.tryAgain}</PrimaryButton>
+          )}
+        </CenteredContent>
+        <div className="px-6 pb-6 flex flex-col items-center">
+          <ContactSupportButton
+            subject="Token loading error"
+            info={{ sessionId: sessionId ?? "", error }}
+          />
+        </div>
+      </div>
+    );
+  }
+
   // Show skeletons while loading
   if (isLoading || options === null) {
     return (

--- a/packages/sdk/src/web/hooks/useWalletFlow.ts
+++ b/packages/sdk/src/web/hooks/useWalletFlow.ts
@@ -50,10 +50,12 @@ export type WalletFlowResult = {
   isConnecting: boolean;
   isLoadingBalances: boolean;
   connectError: string | null;
+  balanceError: string | null;
   connect: () => Promise<void>;
   connectWithProvider: (provider: EthereumProvider) => Promise<void>;
   connectWithSolanaProvider: (provider: SolanaProvider) => Promise<void>;
   retryConnect: () => Promise<void>;
+  retryBalances: () => void;
   sendTransaction: (
     token: WalletPaymentOption,
     amountUsd: number,
@@ -74,6 +76,7 @@ export function useWalletFlow(
   const [isConnecting, setIsConnecting] = useState(false);
   const [isLoadingBalances, setIsLoadingBalances] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [balanceError, setBalanceError] = useState<string | null>(null);
   const currentFetchRef = useRef<string | null>(null);
   const evmProviderRef = useRef<EthereumProvider | null>(null);
   const solanaProviderRef = useRef<SolanaProvider | null>(null);
@@ -83,7 +86,11 @@ export function useWalletFlow(
   const fetchBalances = useCallback(
     async (walletData: WalletData, showLoading: boolean) => {
       if (!walletData.evmAddress && !walletData.solAddress) return;
-      if (!clientSecret) return;
+      if (!clientSecret) {
+        setBalanceError("missing authentication");
+        setIsLoadingBalances(false);
+        return;
+      }
 
       const cacheKey = makeCacheKey(sessionId, walletData);
 
@@ -129,9 +136,17 @@ export function useWalletFlow(
             fetchedAt: Date.now(),
           };
         }
-        if (currentFetchRef.current === cacheKey) setBalances(result);
+        if (currentFetchRef.current === cacheKey) {
+          setBalances(result);
+          setBalanceError(null);
+        }
       } catch (err) {
         console.error("failed to fetch balances:", err);
+        if (currentFetchRef.current === cacheKey) {
+          setBalanceError(
+            err instanceof Error ? err.message : t.somethingWentWrong,
+          );
+        }
       } finally {
         if (currentFetchRef.current === cacheKey) setIsLoadingBalances(false);
       }
@@ -231,6 +246,13 @@ export function useWalletFlow(
     },
     [fetchBalances],
   );
+
+  const retryBalances = useCallback(() => {
+    if (wallet) {
+      setBalanceError(null);
+      fetchBalances(wallet, true);
+    }
+  }, [wallet, fetchBalances]);
 
   const retryConnect = useCallback(async () => {
     if (solanaProviderRef.current) {
@@ -378,10 +400,12 @@ export function useWalletFlow(
     isConnecting,
     isLoadingBalances,
     connectError,
+    balanceError,
     connect,
     connectWithProvider,
     connectWithSolanaProvider,
     retryConnect,
+    retryBalances,
     sendTransaction,
   };
 }


### PR DESCRIPTION
## Summary
- Add `balanceError` state and `retryBalances` callback to `useWalletFlow`
- Show error message + retry button in `SelectTokenPage` instead of infinite skeleton rows
- When `clientSecret` is missing or API errors occur, `fetchBalances` now sets an error state instead of silently failing

## Context
After connecting a wallet on `/session/:id`, if `?cs=` is missing from the URL or the API returns an error, `fetchBalances` silently failed — `balances` stayed `null` forever and the UI showed infinite skeleton loading rows. Now users see an error message with a retry button and contact support link.

## Test plan
- [ ] Connect wallet on `/session/:id?cs=<valid>` — token options load normally
- [ ] Navigate to `/session/:id` without `?cs=` — error message shown instead of infinite skeletons
- [ ] Use invalid clientSecret — error with retry button shown
- [ ] Click retry button — re-attempts balance fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daimo-eth/pay/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
