### PR TITLE
fix: prevent double back button after selecting deeplink wallet

### DIFF
--- a/packages/sdk/src/web/hooks/useSessionNav.ts
+++ b/packages/sdk/src/web/hooks/useSessionNav.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   NavNode,
   NavNodeChooseOption,
@@ -5,7 +6,6 @@ import type {
   SessionWithNav,
 } from "../api/navTree.js";
 import type { WalletPaymentOption } from "../api/walletTypes.js";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useDaimoClient } from "./DaimoClientContext.js";
 import { formatUserError } from "./formatUserError.js";
@@ -307,7 +307,10 @@ export function useSessionNav(
   );
 
   const handleBack = useCallback(() => {
-    logNavEvent(session.sessionId, session.clientSecret, { ...getNodeCtx(), action: "nav_back" });
+    logNavEvent(session.sessionId, session.clientSecret, {
+      ...getNodeCtx(),
+      action: "nav_back",
+    });
 
     setStack((prev) => {
       if (prev.length === 0) return prev;
@@ -417,7 +420,10 @@ export function useSessionNav(
   }, [topEntry, session.navTree, fetchTronAddress, fetchExchangeUrl]);
 
   const handleRefresh = useCallback(async () => {
-    logNavEvent(session.sessionId, session.clientSecret, { ...getNodeCtx(), action: "flow_refresh" });
+    logNavEvent(session.sessionId, session.clientSecret, {
+      ...getNodeCtx(),
+      action: "flow_refresh",
+    });
 
     try {
       const { session: newSession } = await client.internal.sessions.recreate(
@@ -443,14 +449,25 @@ export function useSessionNav(
         pendingWalletRef.current = wallet;
         setStack((prev) => [
           ...prev,
-          { type: "wallet-choose-chain", nodeId: "InjectedWallet", walletName, walletIcon },
+          {
+            type: "wallet-choose-chain",
+            nodeId: "InjectedWallet",
+            walletName,
+            walletIcon,
+          },
         ]);
         return;
       }
 
       setStack((prev) => [
         ...prev,
-        { type: "wallet-connect", nodeId: "InjectedWallet", walletName, walletIcon, autoNav: true },
+        {
+          type: "wallet-connect",
+          nodeId: "InjectedWallet",
+          walletName,
+          walletIcon,
+          autoNav: true,
+        },
       ]);
       if (wallet.solanaProvider) {
         walletFlow?.connectWithSolanaProvider(wallet.solanaProvider);
@@ -469,7 +486,13 @@ export function useSessionNav(
 
       setStack((prev) => [
         ...prev,
-        { type: "wallet-connect", nodeId: "InjectedWallet", walletName, walletIcon, autoNav: true },
+        {
+          type: "wallet-connect",
+          nodeId: "InjectedWallet",
+          walletName,
+          walletIcon,
+          autoNav: true,
+        },
       ]);
 
       if (chain === "solana" && wallet.solanaProvider) {
@@ -554,11 +577,7 @@ export function useSessionNav(
   useEffect(() => {
     if (!isOpen) return;
 
-    if (
-      topEntry &&
-      topEntry.type !== "choose-option" &&
-      topEntry.type !== "deeplink"
-    ) {
+    if (topEntry && topEntry.type !== "choose-option") {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Remove `deeplink` from the auto-nav guard condition in `useSessionNav.ts` so the effect only runs for `choose-option` entries
- Deeplink entries are leaf nodes that don't need auto-navigation; the previous code incorrectly pushed a duplicate stack entry, requiring users to click back twice

## Test plan
- [x] Open SDK modal → "deposit with wallet" → "other" → select a deeplink wallet
- [x] Confirm wallet connection page opens
- [x] Click back once → should return to wallet selection menu (not require two clicks)
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daimo-eth/pay/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
