### PR TITLE
add base CADC token

### DIFF
--- a/packages/sdk/src/common/token.ts
+++ b/packages/sdk/src/common/token.ts
@@ -40,6 +40,7 @@ export type Token = {
 
 export enum TokenLogo {
   BNB = "https://daimo.com/coin-logos/bnb.png",
+  CADC = "https://loon.finance/assets/cadc-3d-0z3reSiq.png",
   CELO = "https://daimo.com/coin-logos/celo.png",
   cUSD = "https://daimo.com/coin-logos/cusd.png",
   DAI = "https://daimo.com/coin-logos/dai.png",
@@ -161,7 +162,7 @@ export const baseCADC: Token = token({
   symbol: "CADC",
   fiatISO: "CAD",
   decimals: 18,
-  logoURI: TokenLogo.USDC,
+  logoURI: TokenLogo.CADC,
 });
 
 export const baseEURC: Token = token({

--- a/packages/sdk/src/common/token.ts
+++ b/packages/sdk/src/common/token.ts
@@ -154,6 +154,16 @@ export const baseUSDC: Token = token({
   logoURI: TokenLogo.USDC,
 });
 
+export const baseCADC: Token = token({
+  chainId: base.chainId,
+  token: getAddress("0x043eB4B75d0805c43D7C834902E335621983Cf03"),
+  name: "CAD Coin",
+  symbol: "CADC",
+  fiatISO: "CAD",
+  decimals: 18,
+  logoURI: TokenLogo.USDC,
+});
+
 export const baseEURC: Token = token({
   chainId: base.chainId,
   token: getAddress("0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42"),
@@ -198,6 +208,7 @@ const baseTokens: Token[] = [
   baseETH,
   baseWETH,
   baseUSDC,
+  baseCADC,
   baseEURC,
   baseUSDbC,
   baseDAI,

--- a/packages/sdk/src/common/token.ts
+++ b/packages/sdk/src/common/token.ts
@@ -40,7 +40,7 @@ export type Token = {
 
 export enum TokenLogo {
   BNB = "https://daimo.com/coin-logos/bnb.png",
-  CADC = "https://loon.finance/assets/cadc-3d-0z3reSiq.png",
+  CADC = "https://daimo.com/coin-logos/cadc.png",
   CELO = "https://daimo.com/coin-logos/celo.png",
   cUSD = "https://daimo.com/coin-logos/cusd.png",
   DAI = "https://daimo.com/coin-logos/dai.png",


### PR DESCRIPTION
## Summary
- add `baseCADC` to the SDK token catalog on Base
- include it in the shared Base token list so common token lookups resolve it

## Validation
- `pnpm --dir packages/sdk build`
- `pnpm --dir packages/sdk exec tsc --noEmit`
