### PR TITLE
harden qr center logo positioning against transform css mismatches

### DIFF
--- a/packages/sdk/src/web/base.css
+++ b/packages/sdk/src/web/base.css
@@ -237,12 +237,16 @@
 .daimo-qr-placeholder-logo {
   z-index: 2;
   position: absolute;
-  left: 50%;
-  top: 50%;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.daimo-qr-placeholder-logo-inner {
   display: flex;
   width: 28%;
   height: 28%;
-  transform: translate(-50%, -50%);
   align-items: center;
   justify-content: center;
 }

--- a/packages/sdk/src/web/components/QRCode.tsx
+++ b/packages/sdk/src/web/components/QRCode.tsx
@@ -152,11 +152,13 @@ function QRCodeContent({ value, image }: { value: string; image?: React.ReactNod
       </svg>
 
       {image && (
-        <div
-          className="daimo-absolute daimo-left-1/2 daimo-top-1/2 daimo-flex -daimo-translate-x-1/2 -daimo-translate-y-1/2 daimo-items-center daimo-justify-center"
-          style={centerLogoStyle}
-        >
-          {image}
+        <div className="daimo-absolute daimo-inset-0 daimo-flex daimo-items-center daimo-justify-center">
+          <div
+            className="daimo-flex daimo-items-center daimo-justify-center"
+            style={centerLogoStyle}
+          >
+            {image}
+          </div>
         </div>
       )}
     </div>
@@ -185,7 +187,9 @@ function QRPlaceholderContent({ image, density = "medium" }: QRPlaceholderProps)
       {/* Logo on top, unaffected by shimmer */}
       {image && (
         <div className="daimo-qr-placeholder-logo">
-          {image}
+          <div className="daimo-qr-placeholder-logo-inner">
+            {image}
+          </div>
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary

This changes the QR center logo from transform-based centering to layout-based centering.

Previously, the logo wrapper in the SDK used `left: 50%`, `top: 50%`, and `translate(-50%, -50%)` to center the token/chain logo inside the QR. During investigation of a merchant report, we found that if that translate transform is missing or overridden, the logo shifts down and right in exactly the way shown in the client screenshot.

This PR removes that dependency.

## What changed

- Updated [QRCode.tsx](/Users/deexie/Downloads/Daimo/daimo-internal/sdk/packages/sdk/src/web/components/QRCode.tsx:154) to center the loaded QR logo with a full-overlay flex container plus an inner 28% logo box.
- Updated [base.css](/Users/deexie/Downloads/Daimo/daimo-internal/sdk/packages/sdk/src/web/base.css:237) to use the same layout-centering approach for the QR placeholder logo.

## Why

The previous centering approach had a brittle failure mode:
- `left: 50%`
- `top: 50%`
- `transform: translate(-50%, -50%)`

If the transform rule disappears, is overridden, or comes from a mismatched CSS bundle, the logo becomes visibly misaligned.

Layout centering avoids depending on that transform rule for correct placement and should be more robust across merchant environments.

## Verification

- `pnpm --filter @daimo/sdk build`
- `pnpm --filter @daimo/pay-web typecheck`

Also verified locally that:
- the QR logo remains centered in the normal state
- the placeholder logo remains centered
- a hostile transform override that breaks the old pattern does not affect the new layout-centered version

## Risk

Low. This is a UI-only hardening change with no API or behavior changes outside QR logo placement.
