### PR TITLE
fix: prevent infinite token skeletons after wallet disconnect

### DIFF
--- a/packages/sdk/src/web/hooks/useWalletFlow.ts
+++ b/packages/sdk/src/web/hooks/useWalletFlow.ts
@@ -402,12 +402,16 @@ export function useWalletFlow(
       if (!accts || accts.length === 0) {
         setWallet((prev) => {
           if (!prev?.solAddress) {
+            currentFetchRef.current = null;
+            setIsLoadingBalances(false);
             setBalances(null);
+            setConnectError(unavailableMsg);
             balanceCache = null;
             return null;
           }
           const updated = { evmAddress: null, solAddress: prev.solAddress };
           balanceCache = null;
+          setConnectError(null);
           fetchBalances(updated, true);
           return updated;
         });
@@ -422,6 +426,7 @@ export function useWalletFlow(
           evmAddress: newAddress,
           solAddress: prev?.solAddress ?? null,
         };
+        setConnectError(null);
         fetchBalances(updated, true);
         return updated;
       });
@@ -451,9 +456,13 @@ export function useWalletFlow(
           solAddress: newSolAddress,
         };
         if (!updated.evmAddress && !updated.solAddress) {
+          currentFetchRef.current = null;
+          setIsLoadingBalances(false);
           setBalances(null);
+          setConnectError(unavailableMsg);
           return null;
         }
+        setConnectError(null);
         fetchBalances(updated, true);
         return updated;
       });


### PR DESCRIPTION
## Summary

Prevents the SDK modal from getting stuck on the Select Token skeleton state after an injected wallet disconnects.

When Rabby disconnects while the modal is already on the token-selection screen, the SDK clears wallet state but leaves the user on a page that treats `options === null` as loading. This change clears the stale loading state and surfaces a recoverable wallet-unavailable state instead of leaving the user stranded on skeleton rows.

## Checklist

- [x] Test live demo locally.
  Verified on phone in Safari and in the Rabby dapp against the local demo flow.

- [x] Publish `@daimo/{common, contract}` if necessary.
  Not necessary for this change.

- [x] Publish `@daimo/pay@<version>` to npm.
  Not part of this PR.

- [x] Update example app to point to new version. Ensure it works.
  Not necessary for this change.

- [x] Update package.json to <version + 1>-dev.
  Not part of this PR.
